### PR TITLE
feat: ホーム画面に設定ボタンを追加

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1177,6 +1177,7 @@ export default function App() {
         onImportJson={handleImportJson}
         onClearCache={handleClearCache}
         onShowPreview={() => setShowPreview(true)}
+        onOpenSettings={() => setShowApiKeySetup(true)}
       />
     );
   }

--- a/components/UploadView.tsx
+++ b/components/UploadView.tsx
@@ -1,8 +1,9 @@
 import React, { useRef, useState, useEffect, useMemo } from 'react';
 import { TRANS } from '../utils/translations';
 import { PhotoRecord, AppMode } from '../types';
-import { Upload, FileUp, HardHat, Camera, MessageSquare, Trash2, Check, Database, AlertCircle, Coins, X, Play } from 'lucide-react';
+import { Upload, FileUp, HardHat, Camera, MessageSquare, Trash2, Check, Database, AlertCircle, Coins, X, Play, Settings } from 'lucide-react';
 import { estimateQuickCost, formatCostJPY } from '../services/usageTracker';
+import { getSelectedModel } from '../services/geminiService';
 
 interface UploadViewProps {
   lang: 'en' | 'ja';
@@ -18,6 +19,7 @@ interface UploadViewProps {
   onImportJson: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onClearCache?: () => void;
   onShowPreview?: () => void;
+  onOpenSettings?: () => void;
 }
 
 const STORAGE_KEY_INSTRUCTION = 'gemini_last_upload_instruction';
@@ -35,7 +37,8 @@ const UploadView: React.FC<UploadViewProps> = ({
   onExportJson,
   onImportJson,
   onClearCache,
-  onShowPreview
+  onShowPreview,
+  onOpenSettings
 }) => {
   const txt = TRANS[lang];
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -130,6 +133,15 @@ const UploadView: React.FC<UploadViewProps> = ({
           {appMode === 'construction' ? <HardHat className="w-6 h-6 text-amber-500" /> : <FileUp className="w-5 h-5" />}
           {txt.appTitle}
         </h1>
+        {/* Settings Button */}
+        <button
+          onClick={onOpenSettings}
+          className="flex items-center gap-2 px-3 py-2 bg-slate-100 hover:bg-slate-200 rounded-lg text-sm text-slate-600 transition-colors"
+          title="API設定"
+        >
+          <Settings className="w-4 h-4" />
+          <span className="hidden sm:inline text-xs font-medium">{getSelectedModel()}</span>
+        </button>
       </div>
 
       {/* --- MAIN INTERACTION AREA --- */}


### PR DESCRIPTION
- 右上に設定アイコンを表示
- 現在選択中のモデル名を表示
- クリックでAPIキー・モデル設定画面を開く