### PR TITLE
feat: 解析前にソートポリシー選択機能を追加

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { PhotoRecord, ProcessingStats, AIAnalysisResult, AppMode, LogEntry } from './types';
+import { PhotoRecord, ProcessingStats, AIAnalysisResult, AppMode, LogEntry, SortPolicy } from './types';
 import { processImageForAI, getPhotoDate } from './utils/imageUtils';
 import { analyzePhotoBatch, identifyTargetPhotos, normalizeDataConsistency, assignSceneIds, refinePairContext, getApiKey, setApiKey as saveApiKey, hasApiKey } from './services/geminiService';
 import { processPhotosWithSmartFlow } from './services/smartFlowService';
@@ -58,6 +58,7 @@ export default function App() {
   const [isStorageLoaded, setIsStorageLoaded] = useState(false);
   const [appMode, setAppMode] = useState<AppMode>('construction');
   const [initialLayout, setInitialLayout] = useState<2 | 3>(3); // Default to 3-up
+  const [currentSortPolicy, setCurrentSortPolicy] = useState<SortPolicy>('chronological');
 
   // Console Logs
   const [logs, setLogs] = useState<LogEntry[]>([]);
@@ -357,21 +358,22 @@ export default function App() {
   };
 
   /**
-   * Sorts photos by time first, then by scene/station.
-   * Time is the primary sort key to maintain chronological order.
+   * Sorts photos based on the current sort policy.
    */
-  const sortPhotosLogical = (records: PhotoRecord[]): PhotoRecord[] => {
-    // 時間優先ソート：まず日時でソートし、同時刻帯はフェーズで調整
-    return [...records].sort((a, b) => {
+  const sortPhotosLogical = (records: PhotoRecord[], policy: SortPolicy = currentSortPolicy): PhotoRecord[] => {
+    const isSafetyPhoto = (r: PhotoRecord) => {
+      const workType = r.analysis?.workType || '';
+      return workType.includes('安全管理') || workType.includes('安全');
+    };
+
+    // 時系列ソート（基本）
+    const chronologicalSort = (a: PhotoRecord, b: PhotoRecord) => {
       const dateA = a.date || 0;
       const dateB = b.date || 0;
-
-      // 5分以内の写真は同時刻帯とみなす
-      const TIME_WINDOW = 5 * 60 * 1000; // 5 minutes
+      const TIME_WINDOW = 5 * 60 * 1000;
       const timeDiff = Math.abs(dateA - dateB);
 
       if (timeDiff <= TIME_WINDOW) {
-        // 同時刻帯の場合：測点→フェーズ順
         const stationA = normalizeStationName(a.analysis?.station) || "ZZZ";
         const stationB = normalizeStationName(b.analysis?.station) || "ZZZ";
         if (stationA !== stationB) return stationA.localeCompare(stationB);
@@ -380,10 +382,53 @@ export default function App() {
         const scoreB = getPhaseScore(b);
         if (scoreA !== scoreB) return scoreA - scoreB;
       }
-
-      // 時間順
       return dateA - dateB;
-    });
+    };
+
+    switch (policy) {
+      case 'chronological':
+        return [...records].sort(chronologicalSort);
+
+      case 'chronological_safety_first': {
+        const safety = records.filter(isSafetyPhoto).sort(chronologicalSort);
+        const others = records.filter(r => !isSafetyPhoto(r)).sort(chronologicalSort);
+        return [...safety, ...others];
+      }
+
+      case 'chronological_safety_last': {
+        const safety = records.filter(isSafetyPhoto).sort(chronologicalSort);
+        const others = records.filter(r => !isSafetyPhoto(r)).sort(chronologicalSort);
+        return [...others, ...safety];
+      }
+
+      case 'chronological_no_safety':
+        return records.filter(r => !isSafetyPhoto(r)).sort(chronologicalSort);
+
+      case 'by_detail': {
+        const groups: { [key: string]: PhotoRecord[] } = {};
+        records.forEach(r => {
+          const key = r.analysis?.detail || r.analysis?.variety || '未分類';
+          if (!groups[key]) groups[key] = [];
+          groups[key].push(r);
+        });
+        const sortedKeys = Object.keys(groups).sort();
+        return sortedKeys.flatMap(key => groups[key].sort(chronologicalSort));
+      }
+
+      case 'by_worktype': {
+        const groups: { [key: string]: PhotoRecord[] } = {};
+        records.forEach(r => {
+          const key = r.analysis?.workType || '未分類';
+          if (!groups[key]) groups[key] = [];
+          groups[key].push(r);
+        });
+        const sortedKeys = Object.keys(groups).sort();
+        return sortedKeys.flatMap(key => groups[key].sort(chronologicalSort));
+      }
+
+      default:
+        return [...records].sort(chronologicalSort);
+    }
   };
 
   /**
@@ -747,8 +792,9 @@ export default function App() {
 
   // --- Pipeline Steps ---
 
-  const handleStartProcessing = async (files: File[], userInstruction: string, useCache: boolean) => {
+  const handleStartProcessing = async (files: File[], userInstruction: string, useCache: boolean, sortPolicy: SortPolicy = 'chronological') => {
     if (!files || files.length === 0) return;
+    setCurrentSortPolicy(sortPolicy); // ソートポリシーを保存
 
     // 1. Initial Validation
     if (files.length > MAX_PHOTOS) {

--- a/components/UploadView.tsx
+++ b/components/UploadView.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState, useEffect, useMemo } from 'react';
 import { TRANS } from '../utils/translations';
-import { PhotoRecord, AppMode } from '../types';
-import { Upload, FileUp, HardHat, Camera, MessageSquare, Trash2, Check, Database, AlertCircle, Coins, X, Play, Settings, MousePointer, Cpu, ChevronDown } from 'lucide-react';
+import { PhotoRecord, AppMode, SortPolicy, SORT_POLICIES } from '../types';
+import { Upload, FileUp, HardHat, Camera, MessageSquare, Trash2, Check, Database, AlertCircle, Coins, X, Play, Settings, MousePointer, Cpu, ChevronDown, ArrowUpDown } from 'lucide-react';
 import { estimateQuickCost, formatCostJPY } from '../services/usageTracker';
 import { getSelectedModel, setSelectedModel, AVAILABLE_MODELS, ModelType } from '../services/geminiService';
 
@@ -12,7 +12,7 @@ interface UploadViewProps {
   appMode: AppMode;
   apiKey: string; // Only for checking availability
   setAppMode: (mode: AppMode) => void;
-  onStartProcessing: (files: File[], instruction: string, useCache: boolean) => void;
+  onStartProcessing: (files: File[], instruction: string, useCache: boolean, sortPolicy: SortPolicy) => void;
   onResume: () => void;
   onCloseProject: () => void;
   onExportJson: () => void;
@@ -50,6 +50,7 @@ const UploadView: React.FC<UploadViewProps> = ({
   const [useCache, setUseCache] = useState(true); // Default to True
   const [pendingFiles, setPendingFiles] = useState<File[] | null>(null); // 確認待ちファイル
   const [selectedModelLocal, setSelectedModelLocal] = useState<ModelType>(getSelectedModel());
+  const [sortPolicy, setSortPolicy] = useState<SortPolicy>('chronological');
 
   // コスト見積もり
   const costEstimate = useMemo(() => {
@@ -104,7 +105,7 @@ const UploadView: React.FC<UploadViewProps> = ({
   const handleConfirmStart = () => {
     if (pendingFiles && pendingFiles.length > 0) {
       setSelectedModel(selectedModelLocal); // モデル設定を保存
-      onStartProcessing(pendingFiles, instruction, useCache);
+      onStartProcessing(pendingFiles, instruction, useCache, sortPolicy);
       setPendingFiles(null);
     }
   };
@@ -317,6 +318,30 @@ const UploadView: React.FC<UploadViewProps> = ({
                         >
                           <div className="font-medium truncate">{model.name.replace('Gemini ', '')}</div>
                           <div className="text-[10px] text-gray-400 truncate">{model.description.split('（')[0]}</div>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Sort Policy Selection */}
+                  <div>
+                    <label className="text-xs font-medium text-gray-600 mb-1.5 block flex items-center gap-1">
+                      <ArrowUpDown className="w-3 h-3" />
+                      並び替え
+                    </label>
+                    <div className="grid grid-cols-2 gap-2">
+                      {SORT_POLICIES.map((policy) => (
+                        <button
+                          key={policy.id}
+                          onClick={() => setSortPolicy(policy.id)}
+                          className={`p-2 rounded-lg border text-xs text-left transition-all ${
+                            sortPolicy === policy.id
+                              ? 'bg-purple-50 border-purple-500 text-purple-700'
+                              : 'bg-white border-gray-200 text-gray-600 hover:border-gray-300'
+                          }`}
+                        >
+                          <div className="font-medium">{policy.name}</div>
+                          <div className="text-[10px] text-gray-400">{policy.description}</div>
                         </button>
                       ))}
                     </div>

--- a/types.ts
+++ b/types.ts
@@ -62,3 +62,21 @@ export interface LogEntry {
   type: 'info' | 'success' | 'error' | 'json';
   details?: any; // For JSON objects
 }
+
+// ソートポリシー
+export type SortPolicy =
+  | 'chronological'           // 時系列順
+  | 'chronological_safety_first' // 時系列（安全管理を先頭に）
+  | 'chronological_safety_last'  // 時系列（安全管理を末尾に）
+  | 'chronological_no_safety'    // 時系列（安全管理を除外）
+  | 'by_detail'               // 細別ごとにグループ化
+  | 'by_worktype';            // 工種ごとにグループ化
+
+export const SORT_POLICIES: { id: SortPolicy; name: string; description: string }[] = [
+  { id: 'chronological', name: '時系列', description: '撮影順に並べる' },
+  { id: 'chronological_safety_first', name: '安全管理優先', description: '安全管理を先頭に、他は時系列' },
+  { id: 'chronological_safety_last', name: '安全管理末尾', description: '安全管理を末尾に、他は時系列' },
+  { id: 'chronological_no_safety', name: '安全管理除外', description: '安全管理写真を非表示' },
+  { id: 'by_detail', name: '細別順', description: '細別ごとにグループ化' },
+  { id: 'by_worktype', name: '工種順', description: '工種ごとにグループ化' },
+];


### PR DESCRIPTION
- 6種類のソートポリシーを追加（時系列、安全管理優先/末尾/除外、細別順、工種順）
- UploadViewの確認画面にソートポリシー選択UIを追加
- sortPhotosLogical関数を各ポリシーに対応するよう拡張