### PR TITLE
fix: 細別順・工種順のソートをマスタデータ順に修正

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import { generateExcel } from './utils/excelGenerator';
 import { saveProjectData, loadProjectData, clearProjectData, getCachedAnalysis, cacheAnalysis, exportDataToJson, importDataFromJson, clearAnalysisCache } from './utils/storage';
 import { fsCache } from './utils/fileSystemCache';
 import { TRANS } from './utils/translations';
+import { getDetailOrderMap, getVarietyOrderMap } from './utils/constructionMaster';
 
 // Components
 import UploadView from './components/UploadView';
@@ -402,17 +403,24 @@ export default function App() {
       }
 
       case 'by_detail': {
+        const detailOrder = getDetailOrderMap();
         const groups: { [key: string]: PhotoRecord[] } = {};
         records.forEach(r => {
           const key = r.analysis?.detail || r.analysis?.variety || '未分類';
           if (!groups[key]) groups[key] = [];
           groups[key].push(r);
         });
-        const sortedKeys = Object.keys(groups).sort();
+        // マスタ順でソート（マスタにないものは末尾）
+        const sortedKeys = Object.keys(groups).sort((a, b) => {
+          const orderA = detailOrder.get(a) ?? 9999;
+          const orderB = detailOrder.get(b) ?? 9999;
+          return orderA - orderB;
+        });
         return sortedKeys.flatMap(key => groups[key].sort(chronologicalSort));
       }
 
       case 'by_detail_safety_first': {
+        const detailOrderSF = getDetailOrderMap();
         const safety = records.filter(isSafetyPhoto).sort(chronologicalSort);
         const others = records.filter(r => !isSafetyPhoto(r));
         const groups: { [key: string]: PhotoRecord[] } = {};
@@ -421,12 +429,18 @@ export default function App() {
           if (!groups[key]) groups[key] = [];
           groups[key].push(r);
         });
-        const sortedKeys = Object.keys(groups).sort();
+        // マスタ順でソート
+        const sortedKeys = Object.keys(groups).sort((a, b) => {
+          const orderA = detailOrderSF.get(a) ?? 9999;
+          const orderB = detailOrderSF.get(b) ?? 9999;
+          return orderA - orderB;
+        });
         const sortedOthers = sortedKeys.flatMap(key => groups[key].sort(chronologicalSort));
         return [...safety, ...sortedOthers];
       }
 
       case 'by_detail_safety_last': {
+        const detailOrderSL = getDetailOrderMap();
         const safety = records.filter(isSafetyPhoto).sort(chronologicalSort);
         const others = records.filter(r => !isSafetyPhoto(r));
         const groups: { [key: string]: PhotoRecord[] } = {};
@@ -435,9 +449,31 @@ export default function App() {
           if (!groups[key]) groups[key] = [];
           groups[key].push(r);
         });
-        const sortedKeys = Object.keys(groups).sort();
+        // マスタ順でソート
+        const sortedKeys = Object.keys(groups).sort((a, b) => {
+          const orderA = detailOrderSL.get(a) ?? 9999;
+          const orderB = detailOrderSL.get(b) ?? 9999;
+          return orderA - orderB;
+        });
         const sortedOthers = sortedKeys.flatMap(key => groups[key].sort(chronologicalSort));
         return [...sortedOthers, ...safety];
+      }
+
+      case 'by_worktype': {
+        const varietyOrder = getVarietyOrderMap();
+        const groups: { [key: string]: PhotoRecord[] } = {};
+        records.forEach(r => {
+          const key = r.analysis?.workType || '未分類';
+          if (!groups[key]) groups[key] = [];
+          groups[key].push(r);
+        });
+        // マスタ順でソート（マスタにないものは末尾）
+        const sortedKeys = Object.keys(groups).sort((a, b) => {
+          const orderA = varietyOrder.get(a) ?? 9999;
+          const orderB = varietyOrder.get(b) ?? 9999;
+          return orderA - orderB;
+        });
+        return sortedKeys.flatMap(key => groups[key].sort(chronologicalSort));
       }
 
       default:

--- a/utils/constructionMaster.ts
+++ b/utils/constructionMaster.ts
@@ -625,3 +625,54 @@ export function inferPhotoCategory(remarkText: string): PhotoCategoryType {
   }
   return "施工状況写真";
 }
+
+// マスタから細別（detail）の順序を取得
+// 同一種別内の細別は定義順に並ぶ
+export function getDetailOrderMap(): Map<string, number> {
+  const orderMap = new Map<string, number>();
+  let order = 0;
+
+  const merged = getMergedHierarchy();
+  const root = merged["直接工事費"] as any;
+
+  // 階層をトラバース（定義順で）
+  for (const catKey in root) {
+    const category = root[catKey];
+    for (const workTypeKey in category) {
+      const workType = category[workTypeKey];
+      for (const varietyKey in workType) {
+        const variety = workType[varietyKey];
+        for (const detailKey in variety) {
+          if (detailKey && detailKey !== 'aliases' && !orderMap.has(detailKey)) {
+            orderMap.set(detailKey, order++);
+          }
+        }
+      }
+    }
+  }
+
+  return orderMap;
+}
+
+// マスタから種別（variety）の順序を取得
+export function getVarietyOrderMap(): Map<string, number> {
+  const orderMap = new Map<string, number>();
+  let order = 0;
+
+  const merged = getMergedHierarchy();
+  const root = merged["直接工事費"] as any;
+
+  for (const catKey in root) {
+    const category = root[catKey];
+    for (const workTypeKey in category) {
+      const workType = category[workTypeKey];
+      for (const varietyKey in workType) {
+        if (varietyKey && !orderMap.has(varietyKey)) {
+          orderMap.set(varietyKey, order++);
+        }
+      }
+    }
+  }
+
+  return orderMap;
+}


### PR DESCRIPTION
- getDetailOrderMap(), getVarietyOrderMap()をconstructionMaster.tsに追加
- by_detailソートがアルファベット順ではなくマスタ定義順に並ぶよう修正
- by_worktypeも同様にマスタ順でソート