### PR TITLE
Add alias feature for pavement work names

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import { fsCache } from './utils/fileSystemCache';
 import { TRANS } from './utils/translations';
 import { getDetailOrderMap, getVarietyOrderMap } from './utils/constructionMaster';
 import { learnFromOrder, getLearnedOrderValue } from './utils/learnedSortOrder';
+import { applyAliasesToRecords, loadAliasSettings, hasAliases } from './utils/workTypeAliases';
 
 // Components
 import UploadView from './components/UploadView';
@@ -1754,6 +1755,18 @@ export default function App() {
         <MasterEditorModal
           lang={lang}
           onClose={() => setShowMasterEditor(false)}
+          onApplyAliasesToSession={() => {
+            const settings = loadAliasSettings();
+            if (!settings.enabled || !hasAliases(settings)) {
+              return { modifiedCount: 0 };
+            }
+            const { modifiedCount, records } = applyAliasesToRecords(photos, settings);
+            if (modifiedCount > 0) {
+              setPhotos(records);
+              addLog(`エイリアス適用: ${modifiedCount}件のデータを変換しました`, 'success');
+            }
+            return { modifiedCount };
+          }}
         />
       ) : !showPreview ? (
         <UploadView

--- a/components/MasterEditorModal.tsx
+++ b/components/MasterEditorModal.tsx
@@ -1,10 +1,20 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { ArrowLeft, Save, Check, Search, ChevronRight, Trash2, Edit2, X, Plus } from 'lucide-react';
+import { ArrowLeft, Save, Check, Search, ChevronRight, Trash2, Edit2, X, Plus, Replace, ToggleLeft, ToggleRight, RefreshCw } from 'lucide-react';
 import { CONSTRUCTION_HIERARCHY } from '../utils/constructionMaster';
+import {
+  loadAliasSettings,
+  saveAliasSettings,
+  applyPreset,
+  clearAliasSettings,
+  PRESET_ALIASES,
+  AliasSettings,
+  PresetKey
+} from '../utils/workTypeAliases';
 
 interface Props {
   onClose: () => void;
   lang: 'en' | 'ja';
+  onApplyAliasesToSession?: () => { modifiedCount: number }; // セッション全体にエイリアス適用
 }
 
 interface WorkTypeData {
@@ -12,7 +22,7 @@ interface WorkTypeData {
   categories: Map<string, any>;
 }
 
-type ViewMode = 'list' | 'detail';
+type ViewMode = 'list' | 'detail' | 'alias';
 
 // カスタマイズデータの型
 interface CustomizationData {
@@ -346,7 +356,7 @@ const EditableTreeView: React.FC<EditableTreeViewProps> = ({
   );
 };
 
-const MasterEditorModal: React.FC<Props> = ({ onClose, lang }) => {
+const MasterEditorModal: React.FC<Props> = ({ onClose, lang, onApplyAliasesToSession }) => {
   const [allWorkTypes] = useState<Map<string, WorkTypeData>>(() => collectAllWorkTypes());
   const [enabledTypes, setEnabledTypes] = useState<Set<string>>(new Set());
   const [hasChanges, setHasChanges] = useState(false);
@@ -354,6 +364,13 @@ const MasterEditorModal: React.FC<Props> = ({ onClose, lang }) => {
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [selectedWorkType, setSelectedWorkType] = useState<WorkTypeData | null>(null);
   const [customization, setCustomization] = useState<CustomizationData>({ deletedPaths: [], renamedPaths: {}, addedEntries: [] });
+
+  // Alias settings state
+  const [aliasSettings, setAliasSettings] = useState<AliasSettings>(loadAliasSettings());
+  const [newWorkTypeFrom, setNewWorkTypeFrom] = useState('');
+  const [newWorkTypeTo, setNewWorkTypeTo] = useState('');
+  const [newVarietyFrom, setNewVarietyFrom] = useState('');
+  const [newVarietyTo, setNewVarietyTo] = useState('');
 
   const txt = {
     title: lang === 'ja' ? '工種セット管理' : 'Work Type Sets',
@@ -373,6 +390,18 @@ const MasterEditorModal: React.FC<Props> = ({ onClose, lang }) => {
     back: lang === 'ja' ? '戻る' : 'Back',
     edit: lang === 'ja' ? '編集' : 'Edit',
     resetCustomization: lang === 'ja' ? 'リセット' : 'Reset',
+    // Alias translations
+    aliasTitle: lang === 'ja' ? '名称エイリアス' : 'Name Aliases',
+    aliasDescription: lang === 'ja' ? '工種・種別名を別名に変換' : 'Convert names to aliases',
+    aliasEnabled: lang === 'ja' ? '有効' : 'Enabled',
+    aliasDisabled: lang === 'ja' ? '無効' : 'Disabled',
+    workTypeAliases: lang === 'ja' ? '工種エイリアス' : 'Work Type Aliases',
+    varietyAliases: lang === 'ja' ? '種別エイリアス' : 'Variety Aliases',
+    from: lang === 'ja' ? '元の名前' : 'Original',
+    to: lang === 'ja' ? '変換後' : 'Alias',
+    add: lang === 'ja' ? '追加' : 'Add',
+    presets: lang === 'ja' ? 'プリセット' : 'Presets',
+    noAliases: lang === 'ja' ? 'エイリアスなし' : 'No aliases',
   };
 
   useEffect(() => {
@@ -453,6 +482,113 @@ const MasterEditorModal: React.FC<Props> = ({ onClose, lang }) => {
         addedEntries: prev.addedEntries.filter(e => !e.parentPath.startsWith(workTypeName + '/') && e.parentPath !== workTypeName)
       }));
       setHasChanges(true);
+    }
+  };
+
+  // Alias handlers
+  const handleToggleAliasEnabled = () => {
+    setAliasSettings(prev => {
+      const updated = { ...prev, enabled: !prev.enabled };
+      saveAliasSettings(updated);
+      return updated;
+    });
+  };
+
+  const handleApplyPreset = (presetKey: PresetKey) => {
+    const newSettings = applyPreset(presetKey);
+    setAliasSettings(newSettings);
+  };
+
+  const handleResetAliases = () => {
+    const newSettings = clearAliasSettings();
+    setAliasSettings(newSettings);
+  };
+
+  const handleAddWorkTypeAlias = () => {
+    if (newWorkTypeFrom.trim() && newWorkTypeTo.trim()) {
+      setAliasSettings(prev => {
+        const updated = {
+          ...prev,
+          mappings: {
+            ...prev.mappings,
+            workType: {
+              ...prev.mappings.workType,
+              [newWorkTypeFrom.trim()]: newWorkTypeTo.trim()
+            }
+          },
+          activePreset: undefined
+        };
+        saveAliasSettings(updated);
+        return updated;
+      });
+      setNewWorkTypeFrom('');
+      setNewWorkTypeTo('');
+    }
+  };
+
+  const handleAddVarietyAlias = () => {
+    if (newVarietyFrom.trim() && newVarietyTo.trim()) {
+      setAliasSettings(prev => {
+        const updated = {
+          ...prev,
+          mappings: {
+            ...prev.mappings,
+            variety: {
+              ...prev.mappings.variety,
+              [newVarietyFrom.trim()]: newVarietyTo.trim()
+            }
+          },
+          activePreset: undefined
+        };
+        saveAliasSettings(updated);
+        return updated;
+      });
+      setNewVarietyFrom('');
+      setNewVarietyTo('');
+    }
+  };
+
+  const handleRemoveWorkTypeAlias = (key: string) => {
+    setAliasSettings(prev => {
+      const newWorkType = { ...prev.mappings.workType };
+      delete newWorkType[key];
+      const updated = {
+        ...prev,
+        mappings: { ...prev.mappings, workType: newWorkType },
+        activePreset: undefined
+      };
+      saveAliasSettings(updated);
+      return updated;
+    });
+  };
+
+  const handleRemoveVarietyAlias = (key: string) => {
+    setAliasSettings(prev => {
+      const newVariety = { ...prev.mappings.variety };
+      delete newVariety[key];
+      const updated = {
+        ...prev,
+        mappings: { ...prev.mappings, variety: newVariety },
+        activePreset: undefined
+      };
+      saveAliasSettings(updated);
+      return updated;
+    });
+  };
+
+  const workTypeAliasEntries = Object.entries(aliasSettings.mappings.workType);
+  const varietyAliasEntries = Object.entries(aliasSettings.mappings.variety);
+  const hasAnyAliases = workTypeAliasEntries.length > 0 || varietyAliasEntries.length > 0;
+
+  // セッションへの適用結果
+  const [applyResult, setApplyResult] = useState<{ modifiedCount: number } | null>(null);
+
+  const handleApplyToSession = () => {
+    if (onApplyAliasesToSession) {
+      const result = onApplyAliasesToSession();
+      setApplyResult(result);
+      // 3秒後にメッセージをクリア
+      setTimeout(() => setApplyResult(null), 3000);
     }
   };
 
@@ -569,6 +705,241 @@ const MasterEditorModal: React.FC<Props> = ({ onClose, lang }) => {
     );
   }
 
+  // エイリアス設定画面
+  if (viewMode === 'alias') {
+    return (
+      <div className="min-h-screen w-full bg-gray-50 flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-amber-600 to-amber-700 text-white sticky top-0 z-10">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => setViewMode('list')}
+              className="p-1.5 hover:bg-white/10 rounded-lg transition-colors"
+            >
+              <ArrowLeft className="w-5 h-5" />
+            </button>
+            <div>
+              <h3 className="text-lg font-bold">{txt.aliasTitle}</h3>
+              <p className="text-xs text-amber-200">{txt.aliasDescription}</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-auto p-4 space-y-4">
+          {/* Enable/Disable Toggle */}
+          <div className="bg-white rounded-lg border shadow-sm p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h4 className="font-medium text-gray-900">エイリアス変換</h4>
+                <p className="text-sm text-gray-500">解析済みデータに一括適用</p>
+              </div>
+              <button
+                onClick={handleToggleAliasEnabled}
+                className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-colors ${
+                  aliasSettings.enabled
+                    ? 'bg-green-100 text-green-700'
+                    : 'bg-gray-100 text-gray-500'
+                }`}
+              >
+                {aliasSettings.enabled ? (
+                  <>
+                    <ToggleRight className="w-5 h-5" />
+                    {txt.aliasEnabled}
+                  </>
+                ) : (
+                  <>
+                    <ToggleLeft className="w-5 h-5" />
+                    {txt.aliasDisabled}
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+
+          {/* Presets */}
+          <div className="bg-white rounded-lg border shadow-sm p-4">
+            <h4 className="font-medium text-gray-900 mb-3">{txt.presets}</h4>
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(PRESET_ALIASES).map(([key, preset]) => (
+                <button
+                  key={key}
+                  onClick={() => handleApplyPreset(key as PresetKey)}
+                  className={`px-3 py-2 rounded-lg text-sm transition-colors ${
+                    aliasSettings.activePreset === key
+                      ? 'bg-amber-100 text-amber-700 border-2 border-amber-300'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200'
+                  }`}
+                >
+                  <div className="font-medium">{preset.name}</div>
+                  <div className="text-xs text-gray-500">{preset.description}</div>
+                </button>
+              ))}
+              <button
+                onClick={handleResetAliases}
+                className="px-3 py-2 rounded-lg text-sm bg-red-50 text-red-600 hover:bg-red-100 border border-red-200 flex items-center gap-1"
+              >
+                <RefreshCw className="w-4 h-4" />
+                {txt.resetCustomization}
+              </button>
+            </div>
+          </div>
+
+          {/* Work Type Aliases */}
+          <div className="bg-white rounded-lg border shadow-sm p-4">
+            <h4 className="font-medium text-gray-900 mb-3">{txt.workTypeAliases}</h4>
+
+            {workTypeAliasEntries.length > 0 ? (
+              <div className="space-y-2 mb-4">
+                {workTypeAliasEntries.map(([from, to]) => (
+                  <div key={from} className="flex items-center gap-2 bg-gray-50 rounded-lg px-3 py-2">
+                    <span className="flex-1 text-sm font-medium text-gray-700">{from}</span>
+                    <span className="text-gray-400">→</span>
+                    <span className="flex-1 text-sm text-amber-600 font-medium">{to}</span>
+                    <button
+                      onClick={() => handleRemoveWorkTypeAlias(from)}
+                      className="p-1 text-red-500 hover:bg-red-100 rounded"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400 mb-4">{txt.noAliases}</p>
+            )}
+
+            {/* Add new work type alias */}
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={newWorkTypeFrom}
+                onChange={(e) => setNewWorkTypeFrom(e.target.value)}
+                placeholder={txt.from}
+                className="flex-1 px-3 py-2 text-sm border rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500"
+              />
+              <span className="text-gray-400">→</span>
+              <input
+                type="text"
+                value={newWorkTypeTo}
+                onChange={(e) => setNewWorkTypeTo(e.target.value)}
+                placeholder={txt.to}
+                className="flex-1 px-3 py-2 text-sm border rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500"
+              />
+              <button
+                onClick={handleAddWorkTypeAlias}
+                disabled={!newWorkTypeFrom.trim() || !newWorkTypeTo.trim()}
+                className="px-3 py-2 rounded-lg text-sm bg-amber-100 text-amber-700 hover:bg-amber-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+              >
+                <Plus className="w-4 h-4" />
+                {txt.add}
+              </button>
+            </div>
+          </div>
+
+          {/* Variety Aliases */}
+          <div className="bg-white rounded-lg border shadow-sm p-4">
+            <h4 className="font-medium text-gray-900 mb-3">{txt.varietyAliases}</h4>
+
+            {varietyAliasEntries.length > 0 ? (
+              <div className="space-y-2 mb-4">
+                {varietyAliasEntries.map(([from, to]) => (
+                  <div key={from} className="flex items-center gap-2 bg-gray-50 rounded-lg px-3 py-2">
+                    <span className="flex-1 text-sm font-medium text-gray-700">{from}</span>
+                    <span className="text-gray-400">→</span>
+                    <span className="flex-1 text-sm text-amber-600 font-medium">{to}</span>
+                    <button
+                      onClick={() => handleRemoveVarietyAlias(from)}
+                      className="p-1 text-red-500 hover:bg-red-100 rounded"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400 mb-4">{txt.noAliases}</p>
+            )}
+
+            {/* Add new variety alias */}
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={newVarietyFrom}
+                onChange={(e) => setNewVarietyFrom(e.target.value)}
+                placeholder={txt.from}
+                className="flex-1 px-3 py-2 text-sm border rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500"
+              />
+              <span className="text-gray-400">→</span>
+              <input
+                type="text"
+                value={newVarietyTo}
+                onChange={(e) => setNewVarietyTo(e.target.value)}
+                placeholder={txt.to}
+                className="flex-1 px-3 py-2 text-sm border rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500"
+              />
+              <button
+                onClick={handleAddVarietyAlias}
+                disabled={!newVarietyFrom.trim() || !newVarietyTo.trim()}
+                className="px-3 py-2 rounded-lg text-sm bg-amber-100 text-amber-700 hover:bg-amber-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+              >
+                <Plus className="w-4 h-4" />
+                {txt.add}
+              </button>
+            </div>
+          </div>
+
+          {/* Preview & Apply Section */}
+          {hasAnyAliases && aliasSettings.enabled && (
+            <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+              <h4 className="font-medium text-amber-800 mb-2">変換プレビュー</h4>
+              <div className="text-sm text-amber-700 mb-4">
+                <p>以下の変換が適用されます：</p>
+                <ul className="mt-2 space-y-1 list-disc list-inside">
+                  {workTypeAliasEntries.map(([from, to]) => (
+                    <li key={`wt-${from}`}>工種: {from} → {to}</li>
+                  ))}
+                  {varietyAliasEntries.map(([from, to]) => (
+                    <li key={`var-${from}`}>種別: {from} → {to}</li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Apply to Session Button */}
+              {onApplyAliasesToSession && (
+                <div className="border-t border-amber-200 pt-4 mt-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-amber-800">現在のセッションに適用</p>
+                      <p className="text-xs text-amber-600">解析済みの写真データを一括変換します</p>
+                    </div>
+                    <button
+                      onClick={handleApplyToSession}
+                      className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors flex items-center gap-2"
+                    >
+                      <Replace className="w-4 h-4" />
+                      適用
+                    </button>
+                  </div>
+                  {applyResult && (
+                    <div className={`mt-3 p-2 rounded text-sm ${
+                      applyResult.modifiedCount > 0
+                        ? 'bg-green-100 text-green-700'
+                        : 'bg-gray-100 text-gray-600'
+                    }`}>
+                      {applyResult.modifiedCount > 0
+                        ? `${applyResult.modifiedCount}件のデータを変換しました`
+                        : '変換対象のデータがありませんでした'}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   // 工種リスト画面（フォールド状態）
   return (
     <div className="min-h-screen w-full bg-gray-50 flex flex-col">
@@ -608,6 +979,20 @@ const MasterEditorModal: React.FC<Props> = ({ onClose, lang }) => {
           {txt.enabled}: <span className="font-bold text-blue-600">{enabledTypes.size}</span> / {allWorkTypes.size}
         </div>
         <div className="flex gap-2">
+          <button
+            onClick={() => setViewMode('alias')}
+            className={`px-3 py-1 text-xs rounded flex items-center gap-1 ${
+              hasAnyAliases && aliasSettings.enabled
+                ? 'bg-amber-100 text-amber-700 hover:bg-amber-200'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            <Replace className="w-3 h-3" />
+            {txt.aliasTitle}
+            {hasAnyAliases && aliasSettings.enabled && (
+              <span className="w-2 h-2 bg-amber-500 rounded-full" />
+            )}
+          </button>
           <button
             onClick={handleSelectAll}
             className="px-3 py-1 text-xs bg-blue-100 text-blue-700 rounded hover:bg-blue-200"

--- a/utils/workTypeAliases.ts
+++ b/utils/workTypeAliases.ts
@@ -1,0 +1,324 @@
+/**
+ * 工種・種別名のエイリアス（別名）管理
+ *
+ * 舗装工系の工事で、書類上の名称を変換するために使用
+ * 例: 「舗装工」→「舗装補修工」、「舗装打換え工」→「アスファルト舗装補修工」
+ */
+
+const ALIAS_STORAGE_KEY = 'worktype_aliases';
+
+// デフォルトのエイリアスプリセット
+export const PRESET_ALIASES = {
+  '舗装補修': {
+    name: '舗装補修工プリセット',
+    description: '舗装工→舗装補修工、舗装打換え工→アスファルト舗装補修工',
+    mappings: {
+      workType: { '舗装工': '舗装補修工' },
+      variety: { '舗装打換え工': 'アスファルト舗装補修工' }
+    }
+  }
+} as const;
+
+export type PresetKey = keyof typeof PRESET_ALIASES;
+
+export interface AliasMapping {
+  workType: Record<string, string>;  // 工種のエイリアス
+  variety: Record<string, string>;   // 種別のエイリアス
+  detail: Record<string, string>;    // 細別のエイリアス（必要に応じて）
+}
+
+export interface AliasSettings {
+  enabled: boolean;
+  mappings: AliasMapping;
+  activePreset?: PresetKey;
+}
+
+const DEFAULT_SETTINGS: AliasSettings = {
+  enabled: false,
+  mappings: {
+    workType: {},
+    variety: {},
+    detail: {}
+  }
+};
+
+/**
+ * エイリアス設定を読み込み
+ */
+export function loadAliasSettings(): AliasSettings {
+  try {
+    const saved = localStorage.getItem(ALIAS_STORAGE_KEY);
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      // マイグレーション: 古い形式から新しい形式へ
+      if (!parsed.mappings) {
+        return DEFAULT_SETTINGS;
+      }
+      return {
+        ...DEFAULT_SETTINGS,
+        ...parsed
+      };
+    }
+  } catch (e) {
+    console.warn('Failed to load alias settings:', e);
+  }
+  return DEFAULT_SETTINGS;
+}
+
+/**
+ * エイリアス設定を保存
+ */
+export function saveAliasSettings(settings: AliasSettings): void {
+  try {
+    localStorage.setItem(ALIAS_STORAGE_KEY, JSON.stringify(settings));
+  } catch (e) {
+    console.error('Failed to save alias settings:', e);
+  }
+}
+
+/**
+ * プリセットを適用
+ */
+export function applyPreset(presetKey: PresetKey): AliasSettings {
+  const preset = PRESET_ALIASES[presetKey];
+  const settings: AliasSettings = {
+    enabled: true,
+    mappings: {
+      workType: { ...preset.mappings.workType },
+      variety: { ...preset.mappings.variety },
+      detail: {}
+    },
+    activePreset: presetKey
+  };
+  saveAliasSettings(settings);
+  return settings;
+}
+
+/**
+ * エイリアス設定をクリア
+ */
+export function clearAliasSettings(): AliasSettings {
+  const settings = DEFAULT_SETTINGS;
+  saveAliasSettings(settings);
+  return settings;
+}
+
+/**
+ * 工種名をエイリアスに変換
+ */
+export function applyWorkTypeAlias(workType: string, settings?: AliasSettings): string {
+  const s = settings || loadAliasSettings();
+  if (!s.enabled) return workType;
+  return s.mappings.workType[workType] || workType;
+}
+
+/**
+ * 種別名をエイリアスに変換
+ */
+export function applyVarietyAlias(variety: string, settings?: AliasSettings): string {
+  const s = settings || loadAliasSettings();
+  if (!s.enabled) return variety;
+  return s.mappings.variety[variety] || variety;
+}
+
+/**
+ * 細別名をエイリアスに変換
+ */
+export function applyDetailAlias(detail: string, settings?: AliasSettings): string {
+  const s = settings || loadAliasSettings();
+  if (!s.enabled) return detail;
+  return s.mappings.detail[detail] || detail;
+}
+
+/**
+ * 解析結果全体にエイリアスを適用
+ */
+export function applyAliases(
+  workType: string,
+  variety: string,
+  detail: string,
+  settings?: AliasSettings
+): { workType: string; variety: string; detail: string } {
+  const s = settings || loadAliasSettings();
+  if (!s.enabled) {
+    return { workType, variety, detail };
+  }
+  return {
+    workType: s.mappings.workType[workType] || workType,
+    variety: s.mappings.variety[variety] || variety,
+    detail: s.mappings.detail[detail] || detail
+  };
+}
+
+/**
+ * カスタムエイリアスを追加
+ */
+export function addCustomAlias(
+  type: 'workType' | 'variety' | 'detail',
+  original: string,
+  alias: string
+): AliasSettings {
+  const settings = loadAliasSettings();
+  settings.mappings[type][original] = alias;
+  settings.activePreset = undefined; // カスタム変更でプリセット解除
+  saveAliasSettings(settings);
+  return settings;
+}
+
+/**
+ * カスタムエイリアスを削除
+ */
+export function removeCustomAlias(
+  type: 'workType' | 'variety' | 'detail',
+  original: string
+): AliasSettings {
+  const settings = loadAliasSettings();
+  delete settings.mappings[type][original];
+  saveAliasSettings(settings);
+  return settings;
+}
+
+/**
+ * エイリアスの有効/無効を切り替え
+ */
+export function toggleAliasEnabled(enabled: boolean): AliasSettings {
+  const settings = loadAliasSettings();
+  settings.enabled = enabled;
+  saveAliasSettings(settings);
+  return settings;
+}
+
+/**
+ * エイリアスが設定されているかチェック
+ */
+export function hasAliases(settings?: AliasSettings): boolean {
+  const s = settings || loadAliasSettings();
+  return (
+    Object.keys(s.mappings.workType).length > 0 ||
+    Object.keys(s.mappings.variety).length > 0 ||
+    Object.keys(s.mappings.detail).length > 0
+  );
+}
+
+/**
+ * エイリアスの逆変換（エイリアス→元の名前）
+ */
+export function reverseAlias(
+  aliasName: string,
+  type: 'workType' | 'variety' | 'detail',
+  settings?: AliasSettings
+): string {
+  const s = settings || loadAliasSettings();
+  const mapping = s.mappings[type];
+  for (const [original, alias] of Object.entries(mapping)) {
+    if (alias === aliasName) {
+      return original;
+    }
+  }
+  return aliasName;
+}
+
+/**
+ * PhotoRecordの配列に対してエイリアスを一括適用
+ * 元のデータを変更するため、呼び出し後はデータが置換済みになる
+ */
+export function applyAliasesToRecords<T extends { analysis?: { workType: string; variety?: string; detail?: string } }>(
+  records: T[],
+  settings?: AliasSettings
+): { modifiedCount: number; records: T[] } {
+  const s = settings || loadAliasSettings();
+  if (!s.enabled || !hasAliases(s)) {
+    return { modifiedCount: 0, records };
+  }
+
+  let modifiedCount = 0;
+
+  const updatedRecords = records.map(record => {
+    if (!record.analysis) return record;
+
+    const original = {
+      workType: record.analysis.workType,
+      variety: record.analysis.variety || '',
+      detail: record.analysis.detail || ''
+    };
+
+    const aliased = applyAliases(original.workType, original.variety, original.detail, s);
+
+    const wasModified =
+      aliased.workType !== original.workType ||
+      aliased.variety !== original.variety ||
+      aliased.detail !== original.detail;
+
+    if (wasModified) {
+      modifiedCount++;
+      return {
+        ...record,
+        analysis: {
+          ...record.analysis,
+          workType: aliased.workType,
+          variety: aliased.variety,
+          detail: aliased.detail
+        }
+      };
+    }
+
+    return record;
+  });
+
+  return { modifiedCount, records: updatedRecords };
+}
+
+/**
+ * 文字列置換を一括実行（直接指定）
+ */
+export function batchReplaceInRecords<T extends { analysis?: { workType: string; variety?: string; detail?: string } }>(
+  records: T[],
+  replacements: { from: string; to: string; field: 'workType' | 'variety' | 'detail' }[]
+): { modifiedCount: number; records: T[] } {
+  if (replacements.length === 0) {
+    return { modifiedCount: 0, records };
+  }
+
+  let modifiedCount = 0;
+
+  const updatedRecords = records.map(record => {
+    if (!record.analysis) return record;
+
+    let modified = false;
+    let newWorkType = record.analysis.workType;
+    let newVariety = record.analysis.variety || '';
+    let newDetail = record.analysis.detail || '';
+
+    for (const { from, to, field } of replacements) {
+      if (field === 'workType' && newWorkType === from) {
+        newWorkType = to;
+        modified = true;
+      }
+      if (field === 'variety' && newVariety === from) {
+        newVariety = to;
+        modified = true;
+      }
+      if (field === 'detail' && newDetail === from) {
+        newDetail = to;
+        modified = true;
+      }
+    }
+
+    if (modified) {
+      modifiedCount++;
+      return {
+        ...record,
+        analysis: {
+          ...record.analysis,
+          workType: newWorkType,
+          variety: newVariety,
+          detail: newDetail
+        }
+      };
+    }
+
+    return record;
+  });
+
+  return { modifiedCount, records: updatedRecords };
+}

--- a/utils/xmlGenerator.ts
+++ b/utils/xmlGenerator.ts
@@ -16,21 +16,21 @@ const escapeXml = (unsafe: string): string => {
 
 export const generatePhotoXML = (records: PhotoRecord[]): string => {
   const dateStr = new Date().toISOString();
-  
+
   let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
   xml += '<!DOCTYPE 工事写真情報 SYSTEM "PHOTO.DTD">\n';
   xml += '<工事写真情報>\n';
   xml += '  <電子納品要領基準>案/2010</電子納品要領基準>\n';
   xml += `  <作成日>${dateStr}</作成日>\n`;
-  
+
   xml += '  <写真情報>\n';
-  
+
   records.forEach((record, index) => {
     if (record.status !== 'done' || !record.analysis) return;
-    
+
     // Sort number: 1-based index padded to 3 digits usually, but simple integer is ok
     const sortNum = index + 1;
-    
+
     xml += '    <写真>\n';
     xml += `      <整理番号>${sortNum}</整理番号>\n`;
     xml += `      <工種>${escapeXml(record.analysis.workType || "")}</工種>\n`;
@@ -45,7 +45,7 @@ export const generatePhotoXML = (records: PhotoRecord[]): string => {
 
   xml += '  </写真情報>\n';
   xml += '</工事写真情報>';
-  
+
   return xml;
 };
 


### PR DESCRIPTION
- utils/workTypeAliases.ts: エイリアス管理ユーティリティを新規作成
  - プリセット機能（舗装補修工プリセット）
  - カスタムエイリアス追加/削除
  - 有効/無効切り替え
  - セッション全体への一括適用機能

- components/MasterEditorModal.tsx: エイリアス設定UIを統合
  - 工種セット管理内に「名称エイリアス」セクションを追加
  - プリセット選択、カスタム追加、プレビュー機能
  - 「現在のセッションに適用」ボタンで解析済みデータを一括変換

- App.tsx: MasterEditorModalにエイリアス適用コールバックを追加

使用例：
- 舗装工 → 舗装補修工
- 舗装打換え工 → アスファルト舗装補修工