### PR TITLE
Enable PDF reading without session data

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,7 @@ import { analyzePhotoBatch, identifyTargetPhotos, getNormalizationProposals, app
 import { processPhotosWithSmartFlow } from './services/smartFlowService';
 import { generateExcel } from './utils/excelGenerator';
 import { saveProjectData, loadProjectData, clearProjectData, getCachedAnalysis, cacheAnalysis, exportDataToJson, importDataFromJson, clearAnalysisCache, saveAnalysisHistory, getAnalysisHistory, getAnalysisHistoryEntry, deleteAnalysisHistory } from './utils/storage';
-import { extractSessionFromPdf, isSmartPdf, extractImagesFromPdf } from './utils/pdfGenerator';
+import { extractSessionFromPdf, isSmartPdf, extractImagesFromPdf, extractTextWithPositions, parsePositionedTextToRecords } from './utils/pdfGenerator';
 import { fsCache } from './utils/fileSystemCache';
 import { TRANS } from './utils/translations';
 import { getDetailOrderMap, getVarietyOrderMap } from './utils/constructionMaster';
@@ -1600,24 +1600,54 @@ export default function App() {
     try {
       // スマートPDFかどうかチェック
       const isSmart = await isSmartPdf(pdfFile);
-      if (!isSmart) {
-        alert(lang === 'ja'
-          ? 'このPDFにはセッションデータが含まれていません。\nGASPhotoAIManagerで作成したPDFのみ読み込み可能です。'
-          : 'This PDF does not contain session data.\nOnly PDFs created by GASPhotoAIManager can be imported.');
-        return;
-      }
 
-      // セッションデータを抽出
-      const sessionData = await extractSessionFromPdf(pdfFile);
-      if (!sessionData || sessionData.length === 0) {
-        alert(lang === 'ja' ? 'セッションデータの抽出に失敗しました' : 'Failed to extract session data');
-        return;
-      }
-
-      // PDFから埋め込み画像を抽出
+      // PDFから埋め込み画像を抽出（先に実行）
       addLog('PDFから画像を抽出中...', 'info');
       const extractedImages = await extractImagesFromPdf(pdfFile);
       addLog(`${extractedImages.length}枚の画像を抽出しました`, 'info');
+
+      let sessionData: Partial<PhotoRecord>[] | null = null;
+
+      if (isSmart) {
+        // セッションデータを抽出
+        sessionData = await extractSessionFromPdf(pdfFile);
+      }
+
+      // セッションデータがない場合、テキスト解析を試みる
+      if (!sessionData || sessionData.length === 0) {
+        if (extractedImages.length === 0) {
+          alert(lang === 'ja'
+            ? 'このPDFから画像を抽出できませんでした。'
+            : 'Could not extract images from this PDF.');
+          return;
+        }
+
+        addLog('セッションデータなし - テキスト解析を試行...', 'info');
+
+        // ユーザーに確認
+        const shouldProceed = window.confirm(
+          lang === 'ja'
+            ? `このPDFにはセッションデータが含まれていません。\n${extractedImages.length}枚の画像が見つかりました。\n\nテキストを解析して復元を試みますか？`
+            : `This PDF does not contain session data.\nFound ${extractedImages.length} images.\n\nWould you like to try text analysis to restore?`
+        );
+
+        if (!shouldProceed) {
+          return;
+        }
+
+        // テキスト解析を実行
+        addLog('PDFテキストを解析中...', 'info');
+        const textData = await extractTextWithPositions(pdfFile);
+
+        // ページ数から1ページあたりの写真数を推測
+        const totalPages = textData.length;
+        const photosPerPage: 2 | 3 = totalPages > 0 && extractedImages.length / totalPages <= 2.5 ? 2 : 3;
+        addLog(`レイアウト推定: ${photosPerPage}枚/ページ`, 'info');
+
+        // テキストからセッションデータを生成
+        sessionData = parsePositionedTextToRecords(textData, extractedImages.length, photosPerPage);
+        addLog(`テキスト解析完了: ${sessionData.length}件のレコードを生成`, 'info');
+      }
 
       // セッションデータと画像をマッチング
       let restoredPhotos: PhotoRecord[] = sessionData.map((data, index) => {

--- a/utils/pdfGenerator.ts
+++ b/utils/pdfGenerator.ts
@@ -104,6 +104,302 @@ export const isSmartPdf = async (pdfFile: File | Blob): Promise<boolean> => {
 };
 
 /**
+ * PDFからテキストを抽出（ページごと）
+ */
+export const extractTextFromPdf = async (
+  pdfFile: File | Blob
+): Promise<{ pageNum: number; texts: string[] }[]> => {
+  const results: { pageNum: number; texts: string[] }[] = [];
+
+  try {
+    const arrayBuffer = await pdfFile.arrayBuffer();
+    const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+
+    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+      const page = await pdf.getPage(pageNum);
+      const textContent = await page.getTextContent();
+
+      const pageTexts: string[] = [];
+      for (const item of textContent.items) {
+        if ('str' in item && item.str.trim()) {
+          pageTexts.push(item.str.trim());
+        }
+      }
+
+      results.push({ pageNum, texts: pageTexts });
+    }
+  } catch (e) {
+    console.error('Failed to extract text from PDF:', e);
+  }
+
+  return results;
+};
+
+/**
+ * 抽出したテキストからPhotoRecord形式に変換
+ * PDFの写真帳レイアウトから工種、細別、測点、備考などを解析
+ */
+export const parseTextToPhotoRecords = (
+  pageTexts: { pageNum: number; texts: string[] }[],
+  imageCount: number,
+  photosPerPage: 2 | 3 = 3
+): Partial<PhotoRecord>[] => {
+  const records: Partial<PhotoRecord>[] = [];
+
+  // 写真帳のフィールドラベル（日本語・英語）
+  const fieldPatterns = {
+    workType: /^(工種|Work\s*Type)$/i,
+    variety: /^(種別|Variety)$/i,
+    detail: /^(細別|Detail)$/i,
+    station: /^(測点|Station)$/i,
+    remarks: /^(備考|Remarks)$/i,
+    date: /^(撮影日時|Date)$/i,
+    measurements: /^(寸法|Measurements?)$/i,
+    description: /^(記事|説明|Description)$/i
+  };
+
+  // ページタイトルのパターン
+  const pageTitlePattern = /^(工事写真帳|Photo\s*Album)$/i;
+  const pageNumPattern = /^Page\s*\d+$/i;
+
+  for (const page of pageTexts) {
+    // テキストをフィルタリング（ページタイトル、ページ番号を除外）
+    const filteredTexts = page.texts.filter(t =>
+      !pageTitlePattern.test(t) && !pageNumPattern.test(t)
+    );
+
+    // 1ページあたりの写真数に基づいてグループ化を試みる
+    // テキストはラベルと値のペアになっていることが多い
+
+    // ラベルを検出して、その次のテキストを値として取得
+    let currentPhotoData: Partial<PhotoRecord['analysis']> = {};
+    let photoCount = 0;
+
+    for (let i = 0; i < filteredTexts.length; i++) {
+      const text = filteredTexts[i];
+      const nextText = filteredTexts[i + 1] || '';
+
+      // ラベルかどうかチェック
+      let isLabel = false;
+      for (const [key, pattern] of Object.entries(fieldPatterns)) {
+        if (pattern.test(text)) {
+          isLabel = true;
+          // 次のテキストが別のラベルでなければ値として使用
+          let isNextLabel = false;
+          for (const p of Object.values(fieldPatterns)) {
+            if (p.test(nextText)) {
+              isNextLabel = true;
+              break;
+            }
+          }
+
+          if (!isNextLabel && nextText) {
+            (currentPhotoData as any)[key] = nextText;
+            i++; // 値を消費
+          }
+          break;
+        }
+      }
+
+      // 撮影日時パターンの直接検出
+      const dateMatch = text.match(/^(\d{4}[\/\-]\d{2}[\/\-]\d{2})\s*(\d{2}:\d{2})?/);
+      if (dateMatch && !isLabel) {
+        // 日時形式のテキストを検出
+        currentPhotoData.date = text;
+      }
+    }
+
+    // このページの写真データがあれば追加
+    if (Object.keys(currentPhotoData).length > 0) {
+      // ページあたりphotosPerPage枚の写真を想定
+      for (let slot = 0; slot < photosPerPage; slot++) {
+        const recordIndex = (page.pageNum - 1) * photosPerPage + slot;
+        if (recordIndex < imageCount) {
+          if (records[recordIndex]) {
+            // 既存のデータとマージ
+            records[recordIndex].analysis = {
+              ...records[recordIndex].analysis,
+              ...currentPhotoData
+            } as any;
+          } else {
+            records[recordIndex] = {
+              fileName: `photo_${recordIndex + 1}.jpg`,
+              status: 'done',
+              analysis: currentPhotoData as any
+            };
+          }
+        }
+      }
+    }
+  }
+
+  // 画像数に合わせてレコードを調整
+  const finalRecords: Partial<PhotoRecord>[] = [];
+  for (let i = 0; i < imageCount; i++) {
+    if (records[i]) {
+      finalRecords.push(records[i]);
+    } else {
+      finalRecords.push({
+        fileName: `photo_${i + 1}.jpg`,
+        status: 'done',
+        analysis: {
+          workType: '',
+          variety: '',
+          detail: '',
+          station: '',
+          remarks: '',
+          description: ''
+        }
+      });
+    }
+  }
+
+  return finalRecords;
+};
+
+/**
+ * より高精度なテキスト解析（位置情報付き）
+ * テキストのY座標を使って、どの写真に対応するかを判定
+ */
+export const extractTextWithPositions = async (
+  pdfFile: File | Blob
+): Promise<{ pageNum: number; items: Array<{ text: string; y: number; x: number }> }[]> => {
+  const results: { pageNum: number; items: Array<{ text: string; y: number; x: number }> }[] = [];
+
+  try {
+    const arrayBuffer = await pdfFile.arrayBuffer();
+    const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+
+    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+      const page = await pdf.getPage(pageNum);
+      const textContent = await page.getTextContent();
+      const viewport = page.getViewport({ scale: 1 });
+
+      const items: Array<{ text: string; y: number; x: number }> = [];
+      for (const item of textContent.items) {
+        if ('str' in item && 'transform' in item && item.str.trim()) {
+          // transform[4] = x, transform[5] = y (PDF座標系)
+          const y = viewport.height - item.transform[5]; // 上からの距離に変換
+          const x = item.transform[4];
+          items.push({ text: item.str.trim(), y, x });
+        }
+      }
+
+      // Y座標でソート
+      items.sort((a, b) => a.y - b.y);
+      results.push({ pageNum, items });
+    }
+  } catch (e) {
+    console.error('Failed to extract text with positions:', e);
+  }
+
+  return results;
+};
+
+/**
+ * 位置情報付きテキストから写真ごとのデータを抽出
+ */
+export const parsePositionedTextToRecords = (
+  pageData: { pageNum: number; items: Array<{ text: string; y: number; x: number }> }[],
+  imageCount: number,
+  photosPerPage: 2 | 3 = 3
+): Partial<PhotoRecord>[] => {
+  const records: Partial<PhotoRecord>[] = [];
+
+  // フィールドラベルパターン
+  const fieldPatterns: { [key: string]: RegExp } = {
+    workType: /^工種$/,
+    variety: /^種別$/,
+    detail: /^細別$/,
+    station: /^測点$/,
+    remarks: /^備考$/,
+    date: /^撮影日時$/,
+    measurements: /^寸法$/,
+    description: /^(記事|説明)$/
+  };
+
+  for (const page of pageData) {
+    // ページ高さを推定（A4: 297mm ≈ 842pt）
+    const pageHeight = 842;
+    const slotHeight = pageHeight / photosPerPage;
+
+    // 各スロットのテキストを収集
+    for (let slot = 0; slot < photosPerPage; slot++) {
+      const slotTop = slot * slotHeight + 50; // ヘッダー分のオフセット
+      const slotBottom = (slot + 1) * slotHeight + 50;
+
+      const slotItems = page.items.filter(item =>
+        item.y >= slotTop && item.y < slotBottom
+      );
+
+      if (slotItems.length === 0) continue;
+
+      const recordIndex = (page.pageNum - 1) * photosPerPage + slot;
+      if (recordIndex >= imageCount) continue;
+
+      const analysis: Partial<PhotoRecord['analysis']> = {
+        workType: '',
+        variety: '',
+        detail: '',
+        station: '',
+        remarks: '',
+        description: ''
+      };
+
+      // ラベルと値のペアを解析
+      for (let i = 0; i < slotItems.length; i++) {
+        const item = slotItems[i];
+
+        for (const [field, pattern] of Object.entries(fieldPatterns)) {
+          if (pattern.test(item.text)) {
+            // 同じ行（y座標が近い）で、x座標が大きいものを値として探す
+            const valueItem = slotItems.find((other, j) =>
+              j > i &&
+              Math.abs(other.y - item.y) < 10 &&
+              other.x > item.x
+            );
+
+            if (valueItem) {
+              (analysis as any)[field] = valueItem.text;
+            }
+            break;
+          }
+        }
+      }
+
+      records[recordIndex] = {
+        fileName: `photo_${recordIndex + 1}.jpg`,
+        status: 'done',
+        analysis: analysis as any
+      };
+    }
+  }
+
+  // 欠落しているレコードを埋める
+  const finalRecords: Partial<PhotoRecord>[] = [];
+  for (let i = 0; i < imageCount; i++) {
+    if (records[i]) {
+      finalRecords.push(records[i]);
+    } else {
+      finalRecords.push({
+        fileName: `photo_${i + 1}.jpg`,
+        status: 'done',
+        analysis: {
+          workType: '',
+          variety: '',
+          detail: '',
+          station: '',
+          remarks: '',
+          description: ''
+        }
+      });
+    }
+  }
+
+  return finalRecords;
+};
+
+/**
  * PDFから埋め込み画像を抽出
  * html2pdfで生成されたPDFには、各ページに画像が埋め込まれている
  */


### PR DESCRIPTION
- pdf.jsのgetTextContentを使ってPDFからテキストを抽出
- テキストの位置情報を使って各画像に対応するデータを解析
- 工種、細別、測点、備考などのラベルと値のペアを検出
- セッションデータがないPDFでもユーザー確認後に復元を試みる