### PR TITLE
feat: エイリアス適用の改善

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -373,6 +373,19 @@ export default function App() {
 
     // Final sort and cleanup
     setPhotos(prev => sortPhotosLogical(prev));
+
+    // エイリアス自動適用（設定が有効な場合）
+    const aliasSettings = loadAliasSettings();
+    if (aliasSettings.enabled && hasAliases(aliasSettings)) {
+      setPhotos(prev => {
+        const { modifiedCount, records } = applyAliasesToRecords(prev, aliasSettings);
+        if (modifiedCount > 0) {
+          addLog(`エイリアス自動適用: ${modifiedCount}件のデータを変換しました`, 'success');
+        }
+        return records;
+      });
+    }
+
     setShowNormalizationModal(false);
     setNormalizationProposals([]);
     setNormalizationOriginals([]);
@@ -385,6 +398,19 @@ export default function App() {
 
     // Final sort without applying corrections
     setPhotos(prev => sortPhotosLogical(prev));
+
+    // エイリアス自動適用（設定が有効な場合）
+    const aliasSettings = loadAliasSettings();
+    if (aliasSettings.enabled && hasAliases(aliasSettings)) {
+      setPhotos(prev => {
+        const { modifiedCount, records } = applyAliasesToRecords(prev, aliasSettings);
+        if (modifiedCount > 0) {
+          addLog(`エイリアス自動適用: ${modifiedCount}件のデータを変換しました`, 'success');
+        }
+        return records;
+      });
+    }
+
     setShowNormalizationModal(false);
     setNormalizationProposals([]);
     setNormalizationOriginals([]);
@@ -1347,6 +1373,18 @@ export default function App() {
         return sorted;
       });
 
+      // 5. エイリアス自動適用（設定が有効な場合）
+      const aliasSettings = loadAliasSettings();
+      if (aliasSettings.enabled && hasAliases(aliasSettings)) {
+        setPhotos(prev => {
+          const { modifiedCount, records } = applyAliasesToRecords(prev, aliasSettings);
+          if (modifiedCount > 0) {
+            addLog(`エイリアス自動適用: ${modifiedCount}件のデータを変換しました`, 'success');
+          }
+          return records;
+        });
+      }
+
       setSuccessMsg(txt.done);
 
     } catch (err: any) {
@@ -1851,6 +1889,18 @@ export default function App() {
         onOpenMasterEditor={() => setShowMasterEditor(true)}
         onReorderPhotos={handleReorderPhotos}
         onOpenStationReplace={() => setShowStationReplace(true)}
+        onApplyAliases={() => {
+          const settings = loadAliasSettings();
+          if (!settings.enabled || !hasAliases(settings)) {
+            return { modifiedCount: 0 };
+          }
+          const { modifiedCount, records } = applyAliasesToRecords(photos, settings);
+          if (modifiedCount > 0) {
+            setPhotos(records);
+            addLog(`エイリアス適用: ${modifiedCount}件のデータを変換しました`, 'success');
+          }
+          return { modifiedCount };
+        }}
       />
       )}
 

--- a/components/PreviewView.tsx
+++ b/components/PreviewView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { FileText, Loader2, Download, Printer, AlertCircle, ZoomIn, Maximize, Home, Wand2, X, Database, FileArchive, Layers, GitCompare, CalendarClock, Check, FileText as FileTextIcon, MousePointer, StopCircle, Settings, ArrowUpDown, Save, ChevronDown, Replace, MoreVertical, Star } from 'lucide-react';
+import { FileText, Loader2, Download, Printer, AlertCircle, ZoomIn, Maximize, Home, Wand2, X, Database, FileArchive, Layers, GitCompare, CalendarClock, Check, FileText as FileTextIcon, MousePointer, StopCircle, Settings, ArrowUpDown, Save, ChevronDown, Replace, MoreVertical, Star, RefreshCw } from 'lucide-react';
 import { TRANS } from '../utils/translations';
 import { PhotoRecord, ProcessingStats, AppMode, AIAnalysisResult, LogEntry } from '../types';
 import PhotoAlbumView from './PhotoAlbumView';
@@ -45,6 +45,7 @@ interface PreviewViewProps {
   onOpenMasterEditor?: () => void;
   onReorderPhotos?: (reorderedPhotos: PhotoRecord[]) => void;
   onOpenStationReplace?: () => void;
+  onApplyAliases?: () => { modifiedCount: number };
 }
 
 const PreviewView: React.FC<PreviewViewProps> = ({
@@ -77,7 +78,8 @@ const PreviewView: React.FC<PreviewViewProps> = ({
   onAbort,
   onOpenMasterEditor,
   onReorderPhotos,
-  onOpenStationReplace
+  onOpenStationReplace,
+  onApplyAliases
 }) => {
   const txt = TRANS[lang];
   const [scale, setScale] = useState(1);
@@ -489,6 +491,22 @@ const PreviewView: React.FC<PreviewViewProps> = ({
                       >
                         <Settings className="w-4 h-4 text-slate-400" />
                         {lang === 'ja' ? 'マスタ管理' : 'Master Data'}
+                      </button>
+                    )}
+                    {onApplyAliases && (
+                      <button
+                        onClick={() => {
+                          const result = onApplyAliases();
+                          setShowToolsMenu(false);
+                          if (result.modifiedCount === 0) {
+                            alert(lang === 'ja' ? 'エイリアスの適用対象がありませんでした。\n設定でエイリアスを有効にし、変換ルールを追加してください。' : 'No aliases to apply. Enable aliases and add mappings in settings.');
+                          }
+                        }}
+                        className="w-full px-3 py-2 text-sm text-left text-slate-200 hover:bg-cyan-600 flex items-center gap-2 transition-colors"
+                        title={lang === 'ja' ? '設定済みのエイリアスを適用します' : 'Apply configured aliases'}
+                      >
+                        <RefreshCw className="w-4 h-4 text-cyan-400" />
+                        {lang === 'ja' ? 'エイリアス適用' : 'Apply Aliases'}
                       </button>
                     )}
                   </div>


### PR DESCRIPTION
- 解析パイプラインの最後に自動でエイリアス適用を追加
- 正規化承認/拒否後にもエイリアス自動適用を追加
- PreviewViewに「エイリアス適用」ボタンを追加（AI不要の手動導線）