### PR TITLE
Allow optional names for example sessions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1021,15 +1021,68 @@ export default function App() {
     addLog(`手動ペアリング完了: ${pairs.length}組`, 'success');
   };
 
-  // 履歴から読み込み
-  const handleLoadHistory = (entry: AnalysisHistoryEntry) => {
-    setPhotos(entry.photos);
-    setInitialInstruction(entry.instruction);
-    setActiveInstruction(entry.instruction);
-    setShowPreview(true);
+  // 履歴から読み込み（軽量版履歴なのでキャッシュから写真を復元）
+  const handleLoadHistory = async (entry: AnalysisHistoryEntry) => {
     setShowHistory(false);
-    addLog(`履歴読み込み: ${entry.photoCount}枚 (${new Date(entry.createdAt).toLocaleString('ja-JP')})`, 'success');
-    setSuccessMsg(`${entry.photoCount}枚の写真を履歴から読み込みました`);
+    setIsProcessing(true);
+    setCurrentStep('履歴から復元中...');
+
+    try {
+      // photoKeysを使ってキャッシュから解析結果を復元
+      const records: PhotoRecord[] = [];
+
+      for (let i = 0; i < entry.photoKeys.length; i++) {
+        const key = entry.photoKeys[i];
+        // キーからファイル情報を抽出（形式: name_size_modified）
+        const parts = key.split('_');
+        const fileName = parts.slice(0, -2).join('_'); // 最後の2つ以外はファイル名
+        const fileSize = parseInt(parts[parts.length - 2]) || 0;
+        const lastModified = parseInt(parts[parts.length - 1]) || 0;
+
+        // サムネイルがあれば使用
+        const thumbnail = entry.thumbnails?.[i] || '';
+
+        const record: PhotoRecord = {
+          fileName,
+          base64: thumbnail,
+          mimeType: 'image/jpeg',
+          fileSize,
+          lastModified,
+          status: 'done',
+          date: lastModified,
+          fromCache: true
+        };
+
+        // キャッシュから解析結果を取得（キーを直接使用）
+        const cachedAnalysis = await getCachedAnalysis(record);
+        if (cachedAnalysis) {
+          record.analysis = cachedAnalysis;
+        }
+
+        records.push(record);
+      }
+
+      setPhotos(records);
+      setStats({
+        total: records.length,
+        processed: records.length,
+        success: records.length,
+        failed: 0,
+        cached: records.length
+      });
+      setInitialInstruction(entry.instruction);
+      setActiveInstruction(entry.instruction);
+      setShowPreview(true);
+      addLog(`履歴読み込み: ${entry.photoCount}枚 (${new Date(entry.createdAt).toLocaleString('ja-JP')})`, 'success');
+      setSuccessMsg(`${entry.photoCount}枚の写真を履歴から読み込みました`);
+    } catch (err: any) {
+      console.error('履歴読み込みエラー:', err);
+      setErrorMsg('履歴の読み込みに失敗しました');
+      addLog('履歴読み込みエラー', 'error', err);
+    } finally {
+      setIsProcessing(false);
+      setCurrentStep('');
+    }
   };
 
   // --- Pipeline Steps ---

--- a/components/PreviewView.tsx
+++ b/components/PreviewView.tsx
@@ -4,7 +4,7 @@ import { TRANS } from '../utils/translations';
 import { PhotoRecord, ProcessingStats, AppMode, AIAnalysisResult, LogEntry } from '../types';
 import PhotoAlbumView from './PhotoAlbumView';
 import ConsolePanel from './ConsolePanel';
-import ExamplesModal from './ExamplesModal';
+import SessionHistoryPanel from './SessionHistoryPanel';
 import { generateZip } from '../utils/zipGenerator';
 import { embedSessionInPdf } from '../utils/pdfGenerator';
 
@@ -94,7 +94,7 @@ const PreviewView: React.FC<PreviewViewProps> = ({
   const [draggedGroupIndex, setDraggedGroupIndex] = useState<number | null>(null);
   const [draggedPhotoIndex, setDraggedPhotoIndex] = useState<number | null>(null);
   const [showToolsMenu, setShowToolsMenu] = useState(false);
-  const [showExamplesModal, setShowExamplesModal] = useState(false);
+  const [showHistoryPanel, setShowHistoryPanel] = useState(false);
   const previewContainerRef = useRef<HTMLDivElement>(null);
   const toolsMenuRef = useRef<HTMLDivElement>(null);
 
@@ -478,11 +478,11 @@ const PreviewView: React.FC<PreviewViewProps> = ({
                       {lang === 'ja' ? '設定' : 'Settings'}
                     </div>
                     <button
-                      onClick={() => { setShowExamplesModal(true); setShowToolsMenu(false); }}
+                      onClick={() => { setShowHistoryPanel(true); setShowToolsMenu(false); }}
                       className="w-full px-3 py-2 text-sm text-left text-slate-200 hover:bg-amber-600 flex items-center gap-2 transition-colors"
                     >
                       <Star className="w-4 h-4 text-amber-400" />
-                      {lang === 'ja' ? 'お手本管理' : 'Examples'}
+                      {lang === 'ja' ? '履歴・お手本管理' : 'History & Examples'}
                     </button>
                     {onOpenMasterEditor && (
                       <button
@@ -651,13 +651,13 @@ const PreviewView: React.FC<PreviewViewProps> = ({
          />
       </div>
 
-      {/* Examples Modal */}
-      <ExamplesModal
-        isOpen={showExamplesModal}
-        onClose={() => setShowExamplesModal(false)}
-        lang={lang}
-        currentPhotos={photos}
-      />
+      {/* History & Examples Panel */}
+      {showHistoryPanel && (
+        <SessionHistoryPanel
+          onLoad={() => {}} // No-op: Already viewing photos in preview mode
+          onClose={() => setShowHistoryPanel(false)}
+        />
+      )}
     </div>
   );
 };

--- a/components/SessionHistoryPanel.tsx
+++ b/components/SessionHistoryPanel.tsx
@@ -1,7 +1,15 @@
 import React, { useState, useEffect } from 'react';
-import { History, Trash2, Download, X, Calendar, Image, FileText } from 'lucide-react';
+import { History, Trash2, X, Calendar, Image, FileText, Star, Check, Edit2 } from 'lucide-react';
 import { AnalysisHistoryEntry } from '../types';
-import { getAnalysisHistory, deleteAnalysisHistory, clearAnalysisHistory } from '../utils/storage';
+import {
+  getAnalysisHistory,
+  deleteAnalysisHistory,
+  clearAnalysisHistory,
+  toggleHistoryAsExample,
+  updateHistoryName,
+  getActiveExampleHistoryId,
+  setActiveExampleHistory
+} from '../utils/storage';
 
 interface Props {
   onLoad: (entry: AnalysisHistoryEntry) => void;
@@ -12,9 +20,13 @@ const SessionHistoryPanel: React.FC<Props> = ({ onLoad, onClose }) => {
   const [entries, setEntries] = useState<AnalysisHistoryEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [confirmClear, setConfirmClear] = useState(false);
+  const [activeExampleId, setActiveExampleId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
 
   useEffect(() => {
     loadHistory();
+    setActiveExampleId(getActiveExampleHistoryId());
   }, []);
 
   const loadHistory = async () => {
@@ -35,6 +47,10 @@ const SessionHistoryPanel: React.FC<Props> = ({ onLoad, onClose }) => {
     try {
       await deleteAnalysisHistory(id);
       setEntries(prev => prev.filter(entry => entry.id !== id));
+      if (activeExampleId === id) {
+        setActiveExampleHistory(null);
+        setActiveExampleId(null);
+      }
     } catch (e) {
       console.error('Failed to delete:', e);
     }
@@ -49,19 +65,70 @@ const SessionHistoryPanel: React.FC<Props> = ({ onLoad, onClose }) => {
       await clearAnalysisHistory();
       setEntries([]);
       setConfirmClear(false);
+      setActiveExampleHistory(null);
+      setActiveExampleId(null);
     } catch (e) {
       console.error('Failed to clear:', e);
     }
   };
 
-  const formatDate = (timestamp: number) => {
-    const date = new Date(timestamp);
-    return date.toLocaleString('ja-JP', {
-      month: 'numeric',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
+  const handleToggleExample = async (entry: AnalysisHistoryEntry, e: React.MouseEvent) => {
+    e.stopPropagation();
+    const newState = !entry.isExampleSession;
+
+    try {
+      const updated = await toggleHistoryAsExample(entry.id, newState);
+      if (updated) {
+        setEntries(prev => prev.map(e => e.id === entry.id ? updated : e));
+
+        // お手本に設定したらアクティブに
+        if (newState) {
+          setActiveExampleHistory(entry.id);
+          setActiveExampleId(entry.id);
+        } else if (activeExampleId === entry.id) {
+          // お手本解除でアクティブだった場合はクリア
+          setActiveExampleHistory(null);
+          setActiveExampleId(null);
+        }
+      }
+    } catch (e) {
+      console.error('Failed to toggle example:', e);
+    }
+  };
+
+  const handleSetActive = async (entry: AnalysisHistoryEntry, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!entry.isExampleSession) return;
+
+    if (activeExampleId === entry.id) {
+      // 解除
+      setActiveExampleHistory(null);
+      setActiveExampleId(null);
+    } else {
+      // 設定
+      setActiveExampleHistory(entry.id);
+      setActiveExampleId(entry.id);
+    }
+  };
+
+  const handleStartEdit = (entry: AnalysisHistoryEntry, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditingId(entry.id);
+    setEditName(entry.name || '');
+  };
+
+  const handleSaveName = async (id: string) => {
+    if (!editName.trim()) {
+      setEditingId(null);
+      return;
+    }
+    try {
+      await updateHistoryName(id, editName.trim());
+      setEntries(prev => prev.map(e => e.id === id ? { ...e, name: editName.trim() } : e));
+    } catch (e) {
+      console.error('Failed to update name:', e);
+    }
+    setEditingId(null);
   };
 
   const formatFullDate = (timestamp: number) => {
@@ -75,15 +142,23 @@ const SessionHistoryPanel: React.FC<Props> = ({ onLoad, onClose }) => {
     });
   };
 
+  const exampleCount = entries.filter(e => e.isExampleSession).length;
+
   return (
     <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center backdrop-blur-sm">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full mx-4 max-h-[80vh] flex flex-col animate-in zoom-in-95 duration-200">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full mx-4 max-h-[85vh] flex flex-col animate-in zoom-in-95 duration-200">
         {/* Header */}
         <div className="bg-gradient-to-r from-purple-600 to-purple-700 text-white p-4 flex items-center justify-between rounded-t-2xl">
           <div className="flex items-center gap-2">
             <History className="w-5 h-5" />
             <h3 className="font-bold text-lg">解析履歴</h3>
             <span className="text-purple-200 text-sm">({entries.length}件)</span>
+            {exampleCount > 0 && (
+              <span className="ml-2 px-2 py-0.5 bg-amber-400 text-amber-900 text-xs rounded-full flex items-center gap-1">
+                <Star className="w-3 h-3" />
+                お手本 {exampleCount}件
+              </span>
+            )}
           </div>
           <button
             onClick={onClose}
@@ -92,6 +167,25 @@ const SessionHistoryPanel: React.FC<Props> = ({ onLoad, onClose }) => {
             <X className="w-5 h-5" />
           </button>
         </div>
+
+        {/* Active Example Banner */}
+        {activeExampleId && (
+          <div className="px-4 py-2 bg-amber-100 border-b border-amber-200 flex items-center gap-2">
+            <Star className="w-4 h-4 text-amber-600 fill-amber-600" />
+            <span className="text-sm text-amber-800 font-medium">
+              お手本適用中: {entries.find(e => e.id === activeExampleId)?.name || '...'}
+            </span>
+            <button
+              onClick={() => {
+                setActiveExampleHistory(null);
+                setActiveExampleId(null);
+              }}
+              className="ml-auto text-xs text-amber-700 hover:text-amber-900 underline"
+            >
+              解除
+            </button>
+          </div>
+        )}
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-4">
@@ -111,18 +205,85 @@ const SessionHistoryPanel: React.FC<Props> = ({ onLoad, onClose }) => {
                 <div
                   key={entry.id}
                   onClick={() => onLoad(entry)}
-                  className="group border border-gray-200 rounded-lg p-3 hover:border-purple-300 hover:bg-purple-50 cursor-pointer transition-colors"
+                  className={`group border rounded-lg p-3 cursor-pointer transition-all ${
+                    entry.isExampleSession
+                      ? activeExampleId === entry.id
+                        ? 'border-amber-400 bg-amber-50 ring-2 ring-amber-300'
+                        : 'border-amber-300 bg-amber-50/50 hover:border-amber-400'
+                      : 'border-gray-200 hover:border-purple-300 hover:bg-purple-50'
+                  }`}
                 >
-                  <div className="flex items-start justify-between">
+                  <div className="flex items-start gap-3">
+                    {/* Thumbnails */}
+                    {entry.thumbnails && entry.thumbnails.length > 0 && (
+                      <div className="flex-shrink-0 flex gap-0.5">
+                        {entry.thumbnails.slice(0, 3).map((thumb, i) => (
+                          <div key={i} className="w-10 h-10 bg-gray-100 rounded overflow-hidden">
+                            <img src={thumb} alt="" className="w-full h-full object-cover" />
+                          </div>
+                        ))}
+                        {entry.photoCount > 3 && (
+                          <div className="w-10 h-10 bg-gray-200 rounded flex items-center justify-center text-xs text-gray-500">
+                            +{entry.photoCount - 3}
+                          </div>
+                        )}
+                      </div>
+                    )}
+
                     <div className="flex-1 min-w-0">
-                      {/* Date & Time */}
-                      <div className="flex items-center gap-2 text-gray-700 font-medium">
-                        <Calendar className="w-4 h-4 text-purple-500" />
-                        <span>{formatFullDate(entry.createdAt)}</span>
+                      {/* Name / Date */}
+                      <div className="flex items-center gap-2">
+                        {editingId === entry.id ? (
+                          <input
+                            type="text"
+                            value={editName}
+                            onChange={(e) => setEditName(e.target.value)}
+                            onBlur={() => handleSaveName(entry.id)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') handleSaveName(entry.id);
+                              if (e.key === 'Escape') setEditingId(null);
+                            }}
+                            onClick={(e) => e.stopPropagation()}
+                            className="flex-1 px-2 py-1 border rounded text-sm focus:ring-2 focus:ring-purple-500"
+                            autoFocus
+                          />
+                        ) : (
+                          <>
+                            <span className="font-medium text-gray-800 truncate">
+                              {entry.name || formatFullDate(entry.createdAt)}
+                            </span>
+                            <button
+                              onClick={(e) => handleStartEdit(entry, e)}
+                              className="p-1 text-gray-400 hover:text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
+                              title="名前を編集"
+                            >
+                              <Edit2 className="w-3 h-3" />
+                            </button>
+                            {entry.isExampleSession && (
+                              <span className="flex items-center gap-1 px-1.5 py-0.5 bg-amber-400 text-amber-900 text-xs rounded">
+                                <Star className="w-3 h-3 fill-amber-900" />
+                                お手本
+                              </span>
+                            )}
+                            {activeExampleId === entry.id && (
+                              <span className="px-1.5 py-0.5 bg-green-500 text-white text-xs rounded">
+                                適用中
+                              </span>
+                            )}
+                          </>
+                        )}
                       </div>
 
+                      {/* Date (if name is different) */}
+                      {entry.name && (
+                        <div className="flex items-center gap-2 mt-1 text-xs text-gray-500">
+                          <Calendar className="w-3 h-3" />
+                          <span>{formatFullDate(entry.createdAt)}</span>
+                        </div>
+                      )}
+
                       {/* Stats */}
-                      <div className="flex items-center gap-4 mt-2 text-sm text-gray-500">
+                      <div className="flex items-center gap-4 mt-1 text-sm text-gray-500">
                         <div className="flex items-center gap-1">
                           <Image className="w-3.5 h-3.5" />
                           <span>{entry.photoCount}枚</span>
@@ -159,14 +320,45 @@ const SessionHistoryPanel: React.FC<Props> = ({ onLoad, onClose }) => {
                       )}
                     </div>
 
-                    {/* Delete Button */}
-                    <button
-                      onClick={(e) => handleDelete(entry.id, e)}
-                      className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg opacity-0 group-hover:opacity-100 transition-all"
-                      title="削除"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
+                    {/* Action Buttons */}
+                    <div className="flex flex-col gap-1">
+                      {/* Toggle Example */}
+                      <button
+                        onClick={(e) => handleToggleExample(entry, e)}
+                        className={`p-2 rounded-lg transition-all ${
+                          entry.isExampleSession
+                            ? 'bg-amber-400 text-amber-900 hover:bg-amber-500'
+                            : 'text-gray-400 hover:text-amber-500 hover:bg-amber-50'
+                        }`}
+                        title={entry.isExampleSession ? 'お手本を解除' : 'お手本に設定'}
+                      >
+                        <Star className={`w-4 h-4 ${entry.isExampleSession ? 'fill-amber-900' : ''}`} />
+                      </button>
+
+                      {/* Apply/Deactivate (only for examples) */}
+                      {entry.isExampleSession && (
+                        <button
+                          onClick={(e) => handleSetActive(entry, e)}
+                          className={`p-2 rounded-lg transition-all ${
+                            activeExampleId === entry.id
+                              ? 'bg-green-500 text-white hover:bg-green-600'
+                              : 'text-gray-400 hover:text-green-500 hover:bg-green-50'
+                          }`}
+                          title={activeExampleId === entry.id ? '適用を解除' : '適用する'}
+                        >
+                          <Check className="w-4 h-4" />
+                        </button>
+                      )}
+
+                      {/* Delete */}
+                      <button
+                        onClick={(e) => handleDelete(entry.id, e)}
+                        className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg opacity-0 group-hover:opacity-100 transition-all"
+                        title="削除"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
                   </div>
                 </div>
               ))}
@@ -175,28 +367,34 @@ const SessionHistoryPanel: React.FC<Props> = ({ onLoad, onClose }) => {
         </div>
 
         {/* Footer */}
-        {entries.length > 0 && (
-          <div className="border-t border-gray-200 p-4 flex justify-between items-center">
-            <button
-              onClick={handleClearAll}
-              className={`text-sm px-3 py-1.5 rounded transition-colors ${
-                confirmClear
-                  ? 'bg-red-500 text-white hover:bg-red-600'
-                  : 'text-gray-500 hover:text-red-500 hover:bg-red-50'
-              }`}
-            >
-              {confirmClear ? '本当に全削除する' : '全履歴を削除'}
-            </button>
+        <div className="border-t border-gray-200 p-4 bg-gray-50 rounded-b-2xl">
+          <div className="flex justify-between items-center">
+            <div className="text-xs text-gray-500">
+              <Star className="w-3 h-3 inline mr-1 text-amber-500" />
+              お手本に設定すると次回解析時にAIの参考例として使用されます
+            </div>
+            {entries.length > 0 && (
+              <button
+                onClick={handleClearAll}
+                className={`text-sm px-3 py-1.5 rounded transition-colors ${
+                  confirmClear
+                    ? 'bg-red-500 text-white hover:bg-red-600'
+                    : 'text-gray-500 hover:text-red-500 hover:bg-red-50'
+                }`}
+              >
+                {confirmClear ? '本当に全削除する' : '全履歴を削除'}
+              </button>
+            )}
             {confirmClear && (
               <button
                 onClick={() => setConfirmClear(false)}
-                className="text-sm text-gray-500 hover:text-gray-700"
+                className="ml-2 text-sm text-gray-500 hover:text-gray-700"
               >
                 キャンセル
               </button>
             )}
           </div>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/types.ts
+++ b/types.ts
@@ -106,7 +106,7 @@ export interface AnalysisSession {
   updatedAt: number;               // 更新日時
 }
 
-// 解析履歴（セッション単位で保存）- 軽量版
+// 解析履歴（セッション単位で保存）- お手本機能統合版
 export interface AnalysisHistoryEntry {
   id: string;                      // ユニークID (UUID)
   sessionKey: string;              // セッション識別キー（重複チェック用）
@@ -116,4 +116,8 @@ export interface AnalysisHistoryEntry {
   workTypes: string[];             // 含まれる工種（サマリー用）
   photoKeys: string[];             // ファイルキーのリスト（軽量）
   modelUsed?: string;              // 使用モデル
+  // お手本機能（統合）
+  isExampleSession?: boolean;      // お手本として使用するか
+  name?: string;                   // セッション名（お手本用、自動生成可）
+  thumbnails?: string[];           // サムネイル（お手本用、最大6枚）
 }

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -685,7 +685,20 @@ export const importRulesFromJson = (jsonStr: string): AnalysisRule[] => {
 // ============================================
 
 /**
- * 解析結果を履歴として保存（軽量版: photoKeysのみ保存）
+ * 履歴用の自動名称を生成
+ */
+const generateHistoryName = (workTypes: string[], createdAt: number): string => {
+  const date = new Date(createdAt);
+  const dateStr = `${date.getMonth() + 1}/${date.getDate()} ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`;
+  if (workTypes.length === 0) {
+    return dateStr;
+  }
+  const typeSummary = workTypes.slice(0, 2).join('・');
+  return workTypes.length > 2 ? `${typeSummary}他 (${dateStr})` : `${typeSummary} (${dateStr})`;
+};
+
+/**
+ * 解析結果を履歴として保存（お手本機能統合版）
  */
 export const saveAnalysisHistory = async (
   photos: PhotoRecord[],
@@ -705,15 +718,26 @@ export const saveAnalysisHistory = async (
   const sessionKey = generateSessionKey(photos);
   const photoKeys = photos.map(p => getFileKey(p));
 
+  // サムネイルを最大6枚抽出
+  const thumbnails = photos
+    .filter(p => p.base64)
+    .slice(0, 6)
+    .map(p => p.base64);
+
+  const createdAt = Date.now();
   const entry: AnalysisHistoryEntry = {
     id: crypto.randomUUID(),
     sessionKey,
-    createdAt: Date.now(),
+    createdAt,
     photoCount: photos.length,
     instruction,
     workTypes,
     photoKeys,
-    modelUsed
+    modelUsed,
+    // お手本機能用（デフォルトはfalse）
+    isExampleSession: false,
+    name: generateHistoryName(workTypes, createdAt),
+    thumbnails
   };
 
   return new Promise((resolve, reject) => {
@@ -828,4 +852,105 @@ export const clearAnalysisHistory = async (): Promise<void> => {
     request.onsuccess = () => resolve();
     request.onerror = () => reject(request.error);
   });
+};
+
+// ============================================
+// 履歴 ⇔ お手本機能 統合
+// ============================================
+
+/**
+ * 履歴エントリーをお手本として設定/解除
+ */
+export const toggleHistoryAsExample = async (
+  id: string,
+  isExample: boolean,
+  name?: string
+): Promise<AnalysisHistoryEntry | null> => {
+  const db = await openDB();
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_HISTORY, 'readwrite');
+    const store = transaction.objectStore(STORE_HISTORY);
+    const getRequest = store.get(id);
+
+    getRequest.onsuccess = () => {
+      const entry = getRequest.result as AnalysisHistoryEntry | undefined;
+      if (!entry) {
+        resolve(null);
+        return;
+      }
+
+      const updated: AnalysisHistoryEntry = {
+        ...entry,
+        isExampleSession: isExample,
+        name: name || entry.name
+      };
+
+      const putRequest = store.put(updated);
+      putRequest.onsuccess = () => resolve(updated);
+      putRequest.onerror = () => reject(putRequest.error);
+    };
+    getRequest.onerror = () => reject(getRequest.error);
+  });
+};
+
+/**
+ * 履歴エントリーの名前を更新
+ */
+export const updateHistoryName = async (id: string, name: string): Promise<void> => {
+  const db = await openDB();
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_HISTORY, 'readwrite');
+    const store = transaction.objectStore(STORE_HISTORY);
+    const getRequest = store.get(id);
+
+    getRequest.onsuccess = () => {
+      const entry = getRequest.result as AnalysisHistoryEntry | undefined;
+      if (!entry) {
+        resolve();
+        return;
+      }
+
+      const updated = { ...entry, name };
+      const putRequest = store.put(updated);
+      putRequest.onsuccess = () => resolve();
+      putRequest.onerror = () => reject(putRequest.error);
+    };
+    getRequest.onerror = () => reject(getRequest.error);
+  });
+};
+
+/**
+ * お手本として設定された履歴を取得
+ */
+export const getExampleHistoryEntries = async (): Promise<AnalysisHistoryEntry[]> => {
+  const all = await getAnalysisHistory();
+  return all.filter(entry => entry.isExampleSession);
+};
+
+/**
+ * アクティブなお手本履歴を設定（LocalStorage）
+ */
+const KEY_ACTIVE_EXAMPLE_HISTORY = 'activeExampleHistoryId';
+
+export const setActiveExampleHistory = (historyId: string | null): void => {
+  if (historyId) {
+    localStorage.setItem(KEY_ACTIVE_EXAMPLE_HISTORY, historyId);
+  } else {
+    localStorage.removeItem(KEY_ACTIVE_EXAMPLE_HISTORY);
+  }
+};
+
+export const getActiveExampleHistoryId = (): string | null => {
+  return localStorage.getItem(KEY_ACTIVE_EXAMPLE_HISTORY);
+};
+
+/**
+ * アクティブなお手本履歴エントリーを取得
+ */
+export const getActiveExampleHistory = async (): Promise<AnalysisHistoryEntry | null> => {
+  const id = getActiveExampleHistoryId();
+  if (!id) return null;
+  return getAnalysisHistoryEntry(id);
 };


### PR DESCRIPTION
- AnalysisHistoryEntryにisExampleSession, name, thumbnailsを追加
- 履歴エントリーを「お手本」としてマーク可能に
- SessionHistoryPanelにお手本トグル・アクティブ設定機能を追加
- ExamplesModalを廃止し、SessionHistoryPanelに統合
- 名前は自動生成（工種+日時）、編集も可能
- お手本設定時に自動でアクティブ化