### PR TITLE
Fix API key validation in reparse process

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1585,7 +1585,10 @@ export default function App() {
     } catch (e: any) {
       console.error(e);
       setErrorMsg("Refine failed: " + e.message);
+    } finally {
       shouldAbortRef.current = false; // Reset abort flag
+      setIsProcessing(false);
+      setCurrentStep("");
     }
   };
 

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -620,6 +620,11 @@ export const identifyTargetPhotos = async (
   onLog?: (msg: string, type: 'info' | 'success' | 'error' | 'json', details?: any) => void,
   shouldAbort?: AbortChecker
 ): Promise<string[]> => {
+  // Early validation: Check API key before proceeding
+  if (!apiKey || !hasApiKey()) {
+    throw new Error('APIキーが設定されていません。設定画面からAPIキーを入力してください。');
+  }
+
   checkAbort(shouldAbort, 'identifyTargetPhotos開始前');
 
   const startTime = performance.now();
@@ -1058,6 +1063,11 @@ export const analyzePhotoBatch = async (
   onReasoningStream?: (text: string) => void,
   ruleSettings?: RuleSettings
 ): Promise<AIAnalysisResult[]> => {
+  // Early validation: Check API key before proceeding
+  if (!apiKey || !hasApiKey()) {
+    throw new Error('APIキーが設定されていません。設定画面からAPIキーを入力してください。');
+  }
+
   const batchStartTime = performance.now();
   const genAI = new GoogleGenAI({ apiKey });
 


### PR DESCRIPTION
- handleRefineAnalysisにfinallyブロックを追加し、エラー時もisProcessingをリセット
- analyzePhotoBatchとidentifyTargetPhotosでAPIキー検証を早期に実行
- APIキー未設定時は明確なエラーメッセージを表示して処理を中断