### PR TITLE
Connect image selection flow in PDF loading

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1738,6 +1738,14 @@ export default function App() {
       // 画像が抽出できなかった場合はフォルダ選択を提案
       let folderImages: { file: File; base64: string; mimeType: string }[] = [];
 
+      // デバッグログ
+      console.log('[PDF Import Debug]', {
+        isSmart,
+        sessionDataLength: sessionData?.length ?? 'null',
+        extractedImagesLength: extractedImages.length,
+        showDirectoryPickerAvailable: 'showDirectoryPicker' in window
+      });
+
       if (!sessionData || sessionData.length === 0) {
         if (extractedImages.length === 0) {
           // 画像がPDFに埋め込まれていない場合、フォルダ選択を提案


### PR DESCRIPTION
handleImportPdf関数にデバッグログを追加し、画像埋め込みなしPDFで
フォルダ選択ダイアログが表示されない問題の原因を特定する