### PR TITLE
Implement lazy loading for PDF features

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,7 +4,7 @@ import { getPhotoDate } from './utils/imageUtils';
 import { applyNormalizationCorrections, NormalizationCorrection, getApiKey, setApiKey as saveApiKey } from './services/geminiService';
 import { generateExcel } from './utils/excelGenerator';
 import { clearAnalysisCache, exportDataToJson, importDataFromJson } from './utils/storage';
-import { extractSessionFromPdf, isSmartPdf, hasIndividualImages, extractImagesFromPdf } from './utils/pdfGenerator';
+// pdfGenerator is dynamically imported when needed to avoid loading heavy PDF libraries upfront
 import { fsCache } from './utils/fileSystemCache';
 import { TRANS } from './utils/translations';
 import { loadAliasSettings, hasAliases, applyAliasesToRecords } from './utils/workTypeAliases';
@@ -33,9 +33,10 @@ import ApiKeySetup from './components/ApiKeySetup';
 import ModelValidation from './components/ModelValidation';
 import UsagePanel from './components/UsagePanel';
 import WorkTypeConfirmModal from './components/WorkTypeConfirmModal';
-import PdfLoadDialog from './components/PdfLoadDialog';
+// PdfLoadDialog is lazy-loaded to reduce initial bundle size
 
 // Lazy-loaded components
+const PdfLoadDialog = lazy(() => import('./components/PdfLoadDialog'));
 const ManualPairingModal = lazy(() => import('./components/ManualPairingModal'));
 const MasterEditorModal = lazy(() => import('./components/MasterEditorModal'));
 const StationReplaceModal = lazy(() => import('./components/StationReplaceModal'));
@@ -283,6 +284,9 @@ export default function App() {
     log(`PDF読み込み: ${pdfFile.name}`);
 
     try {
+      // Dynamic import of pdfGenerator to avoid loading heavy PDF libraries upfront
+      const { isSmartPdf, hasIndividualImages, extractImagesFromPdf, extractSessionFromPdf } = await import('./utils/pdfGenerator');
+
       let images: Array<{ fileName: string; base64: string; mimeType: string }> = [];
       let captionData: Record<string, any> | null = null;
       const isSmart = await isSmartPdf(pdfFile);
@@ -412,12 +416,16 @@ export default function App() {
   // Render
   return (
     <>
-      <PdfLoadDialog
-        isOpen={modals.showPdfLoadDialog}
-        onClose={() => { modals.setShowPdfLoadDialog(false); if (photos.length > 0) setShowPreview(true); }}
-        onLoad={handlePdfLoad}
-        lang={lang}
-      />
+      {modals.showPdfLoadDialog && (
+        <Suspense fallback={<LoadingFallback />}>
+          <PdfLoadDialog
+            isOpen={modals.showPdfLoadDialog}
+            onClose={() => { modals.setShowPdfLoadDialog(false); if (photos.length > 0) setShowPreview(true); }}
+            onLoad={handlePdfLoad}
+            lang={lang}
+          />
+        </Suspense>
+      )}
 
       {modals.showApiKeySetup && (
         <ApiKeySetup

--- a/components/PdfLoadDialog.tsx
+++ b/components/PdfLoadDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { FileText, FolderOpen, Loader2, AlertTriangle, X, Upload } from 'lucide-react';
-import { isSmartPdf, hasIndividualImages } from '../utils/pdfGenerator';
+// pdfGenerator is dynamically imported when needed to avoid loading heavy PDF libraries upfront
 
 interface PdfLoadDialogProps {
   isOpen: boolean;
@@ -45,6 +45,10 @@ const PdfLoadDialog: React.FC<PdfLoadDialogProps> = ({ isOpen, onClose, onLoad, 
 
     try {
       pushLog('PDFを解析中...');
+
+      // Dynamic import of pdfGenerator to avoid loading heavy PDF libraries upfront
+      const { isSmartPdf, hasIndividualImages } = await import('../utils/pdfGenerator');
+
       const isSmart = await isSmartPdf(file);
       const hasImages = await hasIndividualImages(file);
 

--- a/components/PreviewView.tsx
+++ b/components/PreviewView.tsx
@@ -6,7 +6,7 @@ import PhotoAlbumView from './PhotoAlbumView';
 import ConsolePanel from './ConsolePanel';
 import SessionHistoryPanel from './SessionHistoryPanel';
 import { generateZip } from '../utils/zipGenerator';
-import { generatePdfWithImages } from '../utils/pdfGenerator';
+// pdfGenerator is dynamically imported when needed to avoid loading heavy PDF libraries upfront
 
 // Declare saveAs (html2pdf is no longer used)
 declare const saveAs: any;
@@ -241,6 +241,9 @@ const PreviewView: React.FC<PreviewViewProps> = ({
     const filename = `construction_album_${new Date().toISOString().slice(0, 10)}.pdf`;
 
     try {
+      // Dynamic import of pdfGenerator to avoid loading heavy PDF libraries upfront
+      const { generatePdfWithImages } = await import('../utils/pdfGenerator');
+
       // pdf-libを使って個別画像埋め込みPDFを生成
       // これにより、PDFから個別の写真を抽出可能になる
       const pdfBlob = await generatePdfWithImages(photos, photosPerPage, '工事写真帳');

--- a/src/generated/codebase-stats.json
+++ b/src/generated/codebase-stats.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2025-12-29T00:08:48.324Z",
+  "generatedAt": "2025-12-29T00:13:54.418Z",
   "totalFiles": 117,
-  "totalLines": 30004,
+  "totalLines": 30019,
   "largeFiles": [
     {
       "path": "utils/pdfGenerator.ts",
@@ -35,8 +35,8 @@
     },
     {
       "path": "components/PreviewView.tsx",
-      "lines": 642,
-      "size": 28993
+      "lines": 645,
+      "size": 29192
     },
     {
       "path": "services/githubSync.ts",
@@ -73,10 +73,10 @@
       "components/ModelValidation.tsx (381行)",
       "components/NormalizationPresetsPanel.tsx (241行)",
       "components/NormalizationPreviewModal.tsx (228行)",
-      "components/PdfLoadDialog.tsx (226行)",
+      "components/PdfLoadDialog.tsx (230行)",
       "components/PersonalStorageSetup.tsx (396行)",
       "components/PhotoAlbumView.tsx (715行)",
-      "components/PreviewView.tsx (642行)",
+      "components/PreviewView.tsx (645行)",
       "components/RefineModal.tsx (523行)",
       "components/SessionHistoryPanel.tsx (404行)",
       "components/SimplePairingMode.tsx (130行)",
@@ -223,11 +223,11 @@
     {
       "id": "refactor-components-PreviewView-tsx",
       "title": "components/PreviewView.tsx をリファクタ",
-      "description": "642行。重複削除・ロジック整理で300行以下を目指す",
+      "description": "645行。重複削除・ロジック整理で300行以下を目指す",
       "file": "components/PreviewView.tsx",
       "priority": "low",
       "status": "todo",
-      "estimatedLines": 342
+      "estimatedLines": 345
     },
     {
       "id": "refactor-services-githubSync-ts",
@@ -259,11 +259,11 @@
     {
       "id": "refactor-App-tsx",
       "title": "App.tsx をリファクタ",
-      "description": "539行。重複削除・ロジック整理で300行以下を目指す",
+      "description": "547行。重複削除・ロジック整理で300行以下を目指す",
       "file": "App.tsx",
       "priority": "low",
       "status": "todo",
-      "estimatedLines": 239
+      "estimatedLines": 247
     },
     {
       "id": "refactor-services-personalStorage-ts",


### PR DESCRIPTION
- pdfGenerator.ts の関数を動的importに変更
- PdfLoadDialog.tsx を React.lazy で遅延読み込み
- PreviewView.tsx の generatePdfWithImages を動的import

初期ロード時のバンドルサイズを削減し、
PDF機能を使用するときにのみ読み込むように最適化