### PR TITLE
feat: 機能フロー可視化と類似モジュール検出を追加

### DIFF
--- a/components/CodebaseHealthDashboard.tsx
+++ b/components/CodebaseHealthDashboard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   ArrowLeft, GitBranch, CheckCircle, AlertTriangle, RefreshCw,
   ChevronDown, ChevronRight, Scale, AlertCircle, PackageX, MoreVertical, ExternalLink,
-  Network, Layers, Zap, FileCode, Copy, Check, ArrowRight
+  Network, Layers, Zap, FileCode, Copy, Check, ArrowRight, TreePine, Folder, GitCompare
 } from 'lucide-react';
 import codebaseStats from '../src/generated/codebase-stats.json';
 
@@ -377,6 +377,174 @@ const DependencyGraph: React.FC<{ modules: any[] }> = ({ modules }) => {
   );
 };
 
+// 機能フローツリー表示
+const FeatureFlowTree: React.FC<{ node: any; level: number }> = ({ node, level }) => {
+  const [expanded, setExpanded] = useState(level < 2);
+  const hasChildren = node.children && node.children.length > 0;
+
+  const typeIcons: Record<string, { icon: string; color: string }> = {
+    screen: { icon: '🖥️', color: 'text-blue-600' },
+    modal: { icon: '📦', color: 'text-purple-600' },
+    panel: { icon: '📋', color: 'text-green-600' },
+    action: { icon: '⚡', color: 'text-orange-600' },
+  };
+
+  const { icon, color } = typeIcons[node.type] || typeIcons.screen;
+
+  return (
+    <div className={`${level > 0 ? 'ml-6 border-l-2 border-gray-200 pl-4' : ''}`}>
+      <div className="flex items-start gap-2 py-1">
+        {hasChildren && (
+          <button onClick={() => setExpanded(!expanded)} className="text-gray-400 hover:text-gray-600 mt-0.5">
+            {expanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+          </button>
+        )}
+        {!hasChildren && <span className="w-4" />}
+        <span className="text-lg">{icon}</span>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <span className={`font-semibold ${color}`}>{node.name}</span>
+            <span className="text-xs text-gray-400 font-mono">{node.component}</span>
+          </div>
+          <p className="text-xs text-gray-500">{node.description}</p>
+          {node.backendModules && node.backendModules.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-1">
+              {node.backendModules.slice(0, 3).map((mod: string, i: number) => (
+                <span key={i} className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded font-mono">
+                  {mod.split('/').pop()}
+                </span>
+              ))}
+              {node.backendModules.length > 3 && (
+                <span className="text-xs text-gray-400">+{node.backendModules.length - 3}</span>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+      {expanded && hasChildren && (
+        <div className="mt-1">
+          {node.children.map((child: any, i: number) => (
+            <FeatureFlowTree key={i} node={child} level={level + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// 裏方モジュールグループカード
+const BackendModuleGroupCard: React.FC<{ group: any }> = ({ group }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const categoryIcons: Record<string, string> = {
+    'AI/解析': '🤖',
+    'ストレージ': '💾',
+    'ソート/整列': '📊',
+    'エクスポート': '📤',
+    '正規化': '🔄',
+    'ユーティリティ': '🔧',
+    'API/通信': '🌐',
+    '状態管理': '📦',
+    'その他': '📁',
+  };
+
+  return (
+    <div className="bg-white rounded-xl border border-amber-200 overflow-hidden">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center justify-between p-4 text-left hover:bg-amber-50"
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-2xl">{categoryIcons[group.category] || '📁'}</span>
+          <div>
+            <h3 className="font-semibold text-gray-900">{group.category}</h3>
+            <p className="text-xs text-gray-500">{group.description}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm bg-amber-100 text-amber-700 px-2 py-0.5 rounded">
+            {group.modules.length} モジュール
+          </span>
+          {expanded ? <ChevronDown className="w-4 h-4 text-gray-400" /> : <ChevronRight className="w-4 h-4 text-gray-400" />}
+        </div>
+      </button>
+      {expanded && (
+        <div className="border-t border-amber-100 p-4 space-y-2">
+          {group.modules.map((mod: any, i: number) => (
+            <div key={i} className="bg-amber-50 rounded-lg p-3">
+              <div className="flex items-start justify-between">
+                <div>
+                  <p className="font-mono text-sm text-gray-900">{mod.path}</p>
+                  {mod.exports.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {mod.exports.map((exp: string, j: number) => (
+                        <span key={j} className="text-xs bg-white text-gray-600 px-1.5 py-0.5 rounded border">
+                          {exp}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                {mod.usedBy.length > 0 && (
+                  <div className="text-right">
+                    <p className="text-xs text-gray-500">使用元:</p>
+                    <p className="text-xs text-gray-700">{mod.usedBy.slice(0, 2).join(', ')}</p>
+                    {mod.usedBy.length > 2 && <p className="text-xs text-gray-400">+{mod.usedBy.length - 2}</p>}
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// 類似モジュールカード
+const SimilarModuleCard: React.FC<{ pair: any }> = ({ pair }) => {
+  const [showPrompt, setShowPrompt] = useState(false);
+  const similarityColor = pair.similarity >= 0.5 ? 'bg-red-100 text-red-700' :
+                          pair.similarity >= 0.4 ? 'bg-orange-100 text-orange-700' :
+                          'bg-yellow-100 text-yellow-700';
+
+  return (
+    <div className="bg-white rounded-xl border border-rose-200 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-2">
+            <span className={`text-xs font-bold px-2 py-0.5 rounded ${similarityColor}`}>
+              {Math.round(pair.similarity * 100)}% 類似
+            </span>
+          </div>
+          <div className="flex items-center gap-2 text-sm">
+            <span className="font-mono bg-gray-100 px-2 py-0.5 rounded">{pair.modules[0]}</span>
+            <ArrowRight className="w-4 h-4 text-gray-400" />
+            <span className="font-mono bg-gray-100 px-2 py-0.5 rounded">{pair.modules[1]}</span>
+          </div>
+          <p className="text-xs text-gray-500 mt-2">{pair.reason}</p>
+        </div>
+        <div className="flex flex-col gap-2">
+          <CopyButton text={pair.comparisonPrompt} label="比較指示をコピー" />
+          <button
+            onClick={() => setShowPrompt(!showPrompt)}
+            className="text-xs text-gray-600 hover:text-gray-900"
+          >
+            {showPrompt ? '詳細を隠す' : '詳細を見る'}
+          </button>
+        </div>
+      </div>
+      {showPrompt && (
+        <div className="mt-4 p-3 bg-gray-50 rounded-lg">
+          <pre className="text-xs text-gray-700 whitespace-pre-wrap overflow-auto max-h-64">
+            {pair.comparisonPrompt}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+};
+
 const CodebaseHealthDashboard: React.FC<CodebaseHealthDashboardProps> = ({ lang, onClose }) => {
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['tasks']));
   const [isLoading, setIsLoading] = useState(true);
@@ -660,6 +828,85 @@ const CodebaseHealthDashboard: React.FC<CodebaseHealthDashboardProps> = ({ lang,
                         </div>
                       ))}
                     </div>
+                  </div>
+                )}
+              </section>
+            )}
+
+            {/* 機能フローツリー */}
+            {(codebaseStats as any).featureFlow && (
+              <section className="bg-gradient-to-br from-emerald-50 to-teal-50 rounded-2xl border-2 border-emerald-200 overflow-hidden">
+                <button onClick={() => toggle('featureFlow')} className="w-full flex items-center justify-between p-5 text-left hover:bg-emerald-100/50">
+                  <div>
+                    <h2 className="text-xl font-bold text-gray-900 flex items-center gap-2">
+                      {expandedSections.has('featureFlow') ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
+                      <TreePine className="w-5 h-5 text-emerald-600" />
+                      {t('機能フローツリー', 'Feature Flow Tree')}
+                    </h2>
+                    <p className="text-sm text-gray-600 mt-1 ml-7">{t('画面とモーダルの階層構造', 'Screen and modal hierarchy')}</p>
+                  </div>
+                </button>
+                {expandedSections.has('featureFlow') && (
+                  <div className="p-5 pt-0">
+                    <div className="bg-white rounded-xl border border-emerald-200 p-4">
+                      <FeatureFlowTree node={(codebaseStats as any).featureFlow} level={0} />
+                    </div>
+                  </div>
+                )}
+              </section>
+            )}
+
+            {/* 裏方モジュールグループ */}
+            {(codebaseStats as any).backendGroups && (codebaseStats as any).backendGroups.length > 0 && (
+              <section className="bg-gradient-to-br from-amber-50 to-orange-50 rounded-2xl border-2 border-amber-200 overflow-hidden">
+                <button onClick={() => toggle('backendGroups')} className="w-full flex items-center justify-between p-5 text-left hover:bg-amber-100/50">
+                  <div>
+                    <h2 className="text-xl font-bold text-gray-900 flex items-center gap-2">
+                      {expandedSections.has('backendGroups') ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
+                      <Folder className="w-5 h-5 text-amber-600" />
+                      {t('裏方モジュール', 'Backend Modules')}
+                    </h2>
+                    <p className="text-sm text-gray-600 mt-1 ml-7">{t('機能別にグループ化されたサービス・ユーティリティ', 'Services and utilities grouped by function')}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="bg-amber-500 text-white text-sm font-bold px-3 py-1 rounded-full">
+                      {(codebaseStats as any).backendGroups.length} {t('カテゴリ', 'categories')}
+                    </span>
+                  </div>
+                </button>
+                {expandedSections.has('backendGroups') && (
+                  <div className="p-5 pt-0 space-y-3">
+                    {(codebaseStats as any).backendGroups.map((group: any, i: number) => (
+                      <BackendModuleGroupCard key={i} group={group} />
+                    ))}
+                  </div>
+                )}
+              </section>
+            )}
+
+            {/* 類似モジュール検出 */}
+            {(codebaseStats as any).similarModules && (codebaseStats as any).similarModules.length > 0 && (
+              <section className="bg-gradient-to-br from-rose-50 to-pink-50 rounded-2xl border-2 border-rose-200 overflow-hidden">
+                <button onClick={() => toggle('similarModules')} className="w-full flex items-center justify-between p-5 text-left hover:bg-rose-100/50">
+                  <div>
+                    <h2 className="text-xl font-bold text-gray-900 flex items-center gap-2">
+                      {expandedSections.has('similarModules') ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
+                      <GitCompare className="w-5 h-5 text-rose-600" />
+                      {t('類似モジュール', 'Similar Modules')}
+                    </h2>
+                    <p className="text-sm text-gray-600 mt-1 ml-7">{t('統合や役割分担の検討が必要な可能性があるモジュール', 'Modules that may need consolidation or role clarification')}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="bg-rose-500 text-white text-sm font-bold px-3 py-1 rounded-full">
+                      {(codebaseStats as any).similarModules.length} {t('ペア', 'pairs')}
+                    </span>
+                  </div>
+                </button>
+                {expandedSections.has('similarModules') && (
+                  <div className="p-5 pt-0 space-y-3">
+                    {(codebaseStats as any).similarModules.map((pair: any, i: number) => (
+                      <SimilarModuleCard key={i} pair={pair} />
+                    ))}
                   </div>
                 )}
               </section>

--- a/scripts/analyze-codebase.ts
+++ b/scripts/analyze-codebase.ts
@@ -76,6 +76,37 @@ interface ImprovementSuggestion {
   prompt: string;  // Claude用の詳細指示
 }
 
+// 機能フローツリー（ユーザー視点の画面遷移）
+interface FeatureFlowNode {
+  id: string;
+  name: string;
+  type: 'screen' | 'modal' | 'panel' | 'action';
+  component: string;  // コンポーネントファイル
+  description: string;
+  children: FeatureFlowNode[];
+  backendModules: string[];  // 使用しているサービス/ユーティリティ
+}
+
+// 裏方モジュールのグループ
+interface BackendModuleGroup {
+  category: string;
+  description: string;
+  modules: {
+    path: string;
+    name: string;
+    exports: string[];
+    usedBy: string[];  // どの画面から使われているか
+  }[];
+}
+
+// 類似モジュール
+interface SimilarModulePair {
+  modules: [string, string];
+  similarity: number;  // 0-1
+  reason: string;
+  comparisonPrompt: string;  // 比較評価のためのClaudeプロンプト
+}
+
 interface CodebaseStats {
   generatedAt: string;
   totalFiles: number;
@@ -92,6 +123,10 @@ interface CodebaseStats {
   componentAnalysis: ComponentAnalysis[];
   suggestions: ImprovementSuggestion[];
   architectureIssues: string[];
+  // 機能フロー・可視化
+  featureFlow: FeatureFlowNode;
+  backendGroups: BackendModuleGroup[];
+  similarModules: SimilarModulePair[];
 }
 
 const ROOT = path.resolve(__dirname, '..');
@@ -564,6 +599,303 @@ ${largeComponents.slice(0, 5).map(c => `- ${c.path}: JSX深度${c.jsxDepth}, use
   return suggestions;
 }
 
+// 機能フローツリーを解析（App.tsxからユーザー画面遷移を抽出）
+function analyzeFeatureFlow(modules: ModuleNode[]): FeatureFlowNode {
+  const appPath = 'App.tsx';
+  const appModule = modules.find(m => m.path === appPath);
+
+  // App.tsx の内容を読み取って画面構造を解析
+  let appContent = '';
+  try {
+    appContent = fs.readFileSync(path.join(ROOT, appPath), 'utf-8');
+  } catch {
+    // ファイルが読めない場合は空のツリーを返す
+    return {
+      id: 'root',
+      name: 'アプリケーション',
+      type: 'screen',
+      component: appPath,
+      description: 'メインエントリーポイント',
+      children: [],
+      backendModules: []
+    };
+  }
+
+  // コンポーネントのインポートを抽出
+  const componentImports = new Map<string, string>();
+  const importRegex = /import\s+(\w+)\s+from\s+['"]\.\/components\/([^'"]+)['"]/g;
+  const lazyRegex = /const\s+(\w+)\s*=\s*lazy\s*\(\s*\(\)\s*=>\s*import\s*\(\s*['"]\.\/components\/([^'"]+)['"]\s*\)/g;
+  let match;
+  while ((match = importRegex.exec(appContent)) !== null) {
+    componentImports.set(match[1], `components/${match[2]}.tsx`);
+  }
+  while ((match = lazyRegex.exec(appContent)) !== null) {
+    const componentPath = match[2].endsWith('.tsx') ? match[2] : `${match[2]}.tsx`;
+    componentImports.set(match[1], `components/${componentPath}`);
+  }
+
+  // hooksのインポートを抽出
+  const hooksUsed: string[] = [];
+  const hooksMatch = appContent.match(/import\s*\{([^}]+)\}\s*from\s*['"]\.\/hooks['"]/);
+  if (hooksMatch) {
+    hooksUsed.push(...hooksMatch[1].split(',').map(h => h.trim()).filter(h => h));
+  }
+
+  // 画面構造を定義
+  const createFlowNode = (
+    id: string,
+    name: string,
+    type: FeatureFlowNode['type'],
+    component: string,
+    description: string,
+    children: FeatureFlowNode[] = []
+  ): FeatureFlowNode => {
+    // このコンポーネントが使用するバックエンドモジュールを特定
+    const backendModules: string[] = [];
+    const compModule = modules.find(m => m.path === component || m.path === component.replace('.tsx', '/index.tsx'));
+    if (compModule) {
+      for (const imp of compModule.imports) {
+        if (imp.startsWith('services/') || imp.startsWith('utils/')) {
+          backendModules.push(imp);
+        }
+      }
+    }
+    return { id, name, type, component, description, children, backendModules };
+  };
+
+  // メイン画面のフロー構造
+  const uploadViewChildren: FeatureFlowNode[] = [
+    createFlowNode('pdf-load', 'PDF読み込み', 'modal', 'components/PdfLoadDialog.tsx', 'PDFファイルから写真を抽出'),
+    createFlowNode('api-key', 'APIキー設定', 'modal', 'components/ApiKeySetup.tsx', 'Gemini APIキーを設定'),
+    createFlowNode('model-validation', 'モデル検証', 'modal', 'components/ModelValidation.tsx', 'APIキーの有効性を確認'),
+    createFlowNode('history', 'セッション履歴', 'panel', 'components/SessionHistoryPanel.tsx', '過去のセッションを読み込み'),
+    createFlowNode('master-editor-upload', 'マスターエディタ', 'modal', 'components/MasterEditorModal.tsx', '工種マスターを編集'),
+    createFlowNode('health-dashboard', 'コードベース健全性', 'panel', 'components/CodebaseHealthDashboard.tsx', 'コードベースの状態を確認'),
+  ];
+
+  const previewViewChildren: FeatureFlowNode[] = [
+    createFlowNode('refine', '再解析', 'modal', 'components/RefineModal.tsx', '写真の分類を再解析'),
+    createFlowNode('manual-pairing', '手動ペアリング', 'modal', 'components/ManualPairingModal.tsx', '写真の手動ペアリング'),
+    createFlowNode('station-replace', '測点置換', 'modal', 'components/StationReplaceModal.tsx', '測点名を一括置換'),
+    createFlowNode('normalization', '正規化プレビュー', 'modal', 'components/NormalizationPreviewModal.tsx', '表記揺れの正規化を確認'),
+    createFlowNode('github-sync', 'GitHub同期', 'panel', 'components/GitHubSyncPanel.tsx', 'マスターをGitHubと同期'),
+    createFlowNode('master-editor-preview', 'マスターエディタ', 'modal', 'components/MasterEditorModal.tsx', '工種マスターを編集'),
+    createFlowNode('interactive-analysis', '対話式解析', 'modal', 'components/InteractiveAnalysisDialog.tsx', '個別写真を対話形式で解析'),
+    createFlowNode('usage-panel', '使用状況', 'panel', 'components/UsagePanel.tsx', 'API使用状況を表示'),
+    createFlowNode('export-excel', 'Excel出力', 'action', 'utils/excelGenerator.ts', '写真台帳をExcelで出力'),
+  ];
+
+  const root: FeatureFlowNode = {
+    id: 'app',
+    name: 'GASPhotoAIManager',
+    type: 'screen',
+    component: appPath,
+    description: '写真管理・AI解析アプリケーション',
+    backendModules: hooksUsed.map(h => `hooks/${h}.ts`),
+    children: [
+      {
+        id: 'upload-view',
+        name: 'アップロード画面',
+        type: 'screen',
+        component: 'components/UploadView.tsx',
+        description: '初期画面。写真のアップロードと設定',
+        backendModules: [],
+        children: uploadViewChildren
+      },
+      {
+        id: 'preview-view',
+        name: 'プレビュー画面',
+        type: 'screen',
+        component: 'components/PreviewView/index.tsx',
+        description: '解析結果のプレビューと編集',
+        backendModules: [],
+        children: previewViewChildren
+      }
+    ]
+  };
+
+  return root;
+}
+
+// 裏方モジュールをカテゴリ別にグループ化
+function groupBackendModules(modules: ModuleNode[], featureFlow: FeatureFlowNode): BackendModuleGroup[] {
+  const groups: BackendModuleGroup[] = [];
+
+  // カテゴリ定義
+  const categoryDefs: { category: string; description: string; patterns: string[] }[] = [
+    { category: 'AI/解析', description: 'Gemini APIを使った画像解析・分類', patterns: ['gemini', 'analysis', 'classifier'] },
+    { category: 'ストレージ', description: 'データの保存・読み込み（IndexedDB、ファイルシステム）', patterns: ['storage', 'cache', 'db', 'indexed'] },
+    { category: 'ソート/整列', description: '写真の並び替え・グルーピング', patterns: ['sort', 'group', 'order', 'layout'] },
+    { category: 'エクスポート', description: 'Excel/PDF出力', patterns: ['excel', 'pdf', 'export', 'generator'] },
+    { category: '正規化', description: '測点名・工種名の表記揺れ統一', patterns: ['normaliz', 'station', 'worktype'] },
+    { category: 'ユーティリティ', description: '汎用ヘルパー関数', patterns: ['util', 'helper', 'common'] },
+    { category: 'API/通信', description: '外部API連携', patterns: ['api', 'fetch', 'http', 'github'] },
+    { category: '状態管理', description: 'アプリ状態のフック', patterns: ['hook', 'state', 'use'] },
+  ];
+
+  // 全コンポーネントから使用されているバックエンドモジュールを収集
+  const usageMap = new Map<string, string[]>();
+  function collectUsage(node: FeatureFlowNode) {
+    for (const backend of node.backendModules) {
+      const existing = usageMap.get(backend) || [];
+      if (!existing.includes(node.name)) {
+        existing.push(node.name);
+      }
+      usageMap.set(backend, existing);
+    }
+    for (const child of node.children) {
+      collectUsage(child);
+    }
+  }
+  collectUsage(featureFlow);
+
+  // サービスとユーティリティモジュールをフィルタ
+  const backendModules = modules.filter(m =>
+    m.path.startsWith('services/') || m.path.startsWith('utils/') || m.path.startsWith('hooks/')
+  );
+
+  // 各カテゴリにモジュールを割り当て
+  const categorized = new Set<string>();
+  for (const def of categoryDefs) {
+    const categoryModules = backendModules.filter(m => {
+      const name = m.path.toLowerCase();
+      return def.patterns.some(p => name.includes(p)) && !categorized.has(m.path);
+    });
+
+    if (categoryModules.length > 0) {
+      const modulesInfo = categoryModules.map(m => {
+        categorized.add(m.path);
+        // export を抽出
+        let exports: string[] = [];
+        try {
+          const content = fs.readFileSync(path.join(ROOT, m.path), 'utf-8');
+          const exportMatches = content.match(/export\s+(?:async\s+)?(?:function|const|class|interface|type)\s+(\w+)/g) || [];
+          exports = exportMatches.map(e => {
+            const match = e.match(/(?:function|const|class|interface|type)\s+(\w+)/);
+            return match ? match[1] : '';
+          }).filter(Boolean);
+        } catch { /* ignore */ }
+
+        return {
+          path: m.path,
+          name: m.path.split('/').pop()?.replace(/\.tsx?$/, '') || m.path,
+          exports: exports.slice(0, 5),  // 最大5つ
+          usedBy: usageMap.get(m.path) || []
+        };
+      });
+
+      groups.push({
+        category: def.category,
+        description: def.description,
+        modules: modulesInfo
+      });
+    }
+  }
+
+  // カテゴリ未分類のモジュール
+  const uncategorized = backendModules.filter(m => !categorized.has(m.path));
+  if (uncategorized.length > 0) {
+    groups.push({
+      category: 'その他',
+      description: '分類されていないモジュール',
+      modules: uncategorized.map(m => ({
+        path: m.path,
+        name: m.path.split('/').pop()?.replace(/\.tsx?$/, '') || m.path,
+        exports: [],
+        usedBy: usageMap.get(m.path) || []
+      }))
+    });
+  }
+
+  return groups;
+}
+
+// 類似モジュールを検出
+function detectSimilarModules(modules: ModuleNode[]): SimilarModulePair[] {
+  const pairs: SimilarModulePair[] = [];
+
+  // 類似判定の基準
+  // 1. 同じカテゴリ内のモジュール
+  // 2. 名前が似ている
+  // 3. import/exportが似ている
+
+  const backendModules = modules.filter(m =>
+    m.path.startsWith('services/') || m.path.startsWith('utils/')
+  );
+
+  // モジュールの内容を読み込んでトークン化
+  const moduleTokens = new Map<string, Set<string>>();
+  for (const mod of backendModules) {
+    try {
+      const content = fs.readFileSync(path.join(ROOT, mod.path), 'utf-8');
+      // 関数名、変数名、キーワードを抽出
+      const tokens = new Set<string>();
+      const matches = content.match(/\b[a-zA-Z_][a-zA-Z0-9_]*\b/g) || [];
+      for (const m of matches) {
+        if (m.length > 3) tokens.add(m.toLowerCase());
+      }
+      moduleTokens.set(mod.path, tokens);
+    } catch { /* ignore */ }
+  }
+
+  // ペアワイズで類似度を計算
+  for (let i = 0; i < backendModules.length; i++) {
+    for (let j = i + 1; j < backendModules.length; j++) {
+      const mod1 = backendModules[i];
+      const mod2 = backendModules[j];
+      const tokens1 = moduleTokens.get(mod1.path);
+      const tokens2 = moduleTokens.get(mod2.path);
+
+      if (!tokens1 || !tokens2 || tokens1.size < 10 || tokens2.size < 10) continue;
+
+      // Jaccard係数で類似度を計算
+      const intersection = new Set([...tokens1].filter(t => tokens2.has(t)));
+      const union = new Set([...tokens1, ...tokens2]);
+      const similarity = intersection.size / union.size;
+
+      // 閾値以上なら類似モジュールとして記録
+      if (similarity > 0.3) {
+        // 共通するトークンから機能を推定
+        const commonTokens = [...intersection].slice(0, 10).join(', ');
+
+        pairs.push({
+          modules: [mod1.path, mod2.path],
+          similarity: Math.round(similarity * 100) / 100,
+          reason: `共通キーワード: ${commonTokens}`,
+          comparisonPrompt: `# モジュール比較: ${mod1.path} vs ${mod2.path}
+
+## 類似度: ${Math.round(similarity * 100)}%
+
+## 比較タスク
+以下の2つのモジュールを比較し、統合または役割分担の改善を検討してください。
+
+### ファイル1: ${mod1.path}
+- インポート数: ${mod1.imports.length}
+- 参照元: ${mod1.importedBy.length}ファイル
+
+### ファイル2: ${mod2.path}
+- インポート数: ${mod2.imports.length}
+- 参照元: ${mod2.importedBy.length}ファイル
+
+## 確認ポイント
+1. 両モジュールの責務は明確に分離されているか
+2. 重複する機能はないか
+3. 統合すべきか、または片方に機能を集約すべきか
+4. 命名規則は一貫しているか
+
+## 出力
+- 現状の問題点（あれば）
+- 改善提案
+- 統合する場合の具体的な手順`
+        });
+      }
+    }
+  }
+
+  // 類似度順にソートして上位を返す
+  return pairs.sort((a, b) => b.similarity - a.similarity).slice(0, 10);
+}
+
 // 健全性チェックを並列実行
 async function runHealthChecks(): Promise<HealthCheck[]> {
   const checkFns = [
@@ -800,6 +1132,18 @@ async function analyzeCodebase(): Promise<CodebaseStats> {
   console.log('💡 Generating improvement suggestions...');
   const suggestions = generateSuggestions(moduleDependencies, componentAnalysis, architectureIssues);
 
+  // 新規分析: 機能フローツリー
+  console.log('🌳 Analyzing feature flow...');
+  const featureFlow = analyzeFeatureFlow(moduleDependencies);
+
+  // 新規分析: 裏方モジュールのグループ化
+  console.log('📦 Grouping backend modules...');
+  const backendGroups = groupBackendModules(moduleDependencies, featureFlow);
+
+  // 新規分析: 類似モジュール検出
+  console.log('🔍 Detecting similar modules...');
+  const similarModules = detectSimilarModules(moduleDependencies);
+
   const stats: CodebaseStats = {
     generatedAt: new Date().toISOString(),
     totalFiles: allFiles.length,
@@ -827,7 +1171,11 @@ async function analyzeCodebase(): Promise<CodebaseStats> {
     moduleDependencies: moduleDependencies.slice(0, 50), // 上位50モジュール
     componentAnalysis: componentAnalysis.slice(0, 20), // 上位20コンポーネント
     suggestions,
-    architectureIssues
+    architectureIssues,
+    // 機能フロー・可視化
+    featureFlow,
+    backendGroups,
+    similarModules
   };
 
   return stats;
@@ -887,6 +1235,27 @@ async function main() {
     console.log('\n🧩 Components needing attention:');
     problematicComponents.slice(0, 3).forEach(c => {
       console.log(`   ⚠️ ${c.path}: ${c.issues.join(', ')}`);
+    });
+  }
+
+  // 機能フローツリー
+  console.log('\n🌳 Feature flow:');
+  console.log(`   ${stats.featureFlow.name}`);
+  for (const child of stats.featureFlow.children) {
+    console.log(`   ├─ ${child.name} (${child.children.length}機能)`);
+  }
+
+  // 裏方モジュールグループ
+  console.log('\n📦 Backend module groups:');
+  for (const group of stats.backendGroups.slice(0, 5)) {
+    console.log(`   📂 ${group.category}: ${group.modules.length}モジュール`);
+  }
+
+  // 類似モジュール
+  if (stats.similarModules.length > 0) {
+    console.log('\n🔍 Similar modules (may need review):');
+    stats.similarModules.slice(0, 3).forEach(pair => {
+      console.log(`   ${Math.round(pair.similarity * 100)}%: ${pair.modules[0]} ⟷ ${pair.modules[1]}`);
     });
   }
 }


### PR DESCRIPTION
- 機能フローツリー解析: App.tsxから画面とモーダルの階層構造を抽出
- 裏方モジュールのグループ化: サービス/ユーティリティを機能別に分類
- 類似モジュール検出: Jaccard係数で類似モジュールを検出し比較プロンプト生成
- ダッシュボードUIに3つの新セクション追加（ツリー表示・カテゴリ一覧・類似比較）