### PR TITLE
Extract custom hooks from React components

### DIFF
--- a/components/ApiKeySetup.tsx
+++ b/components/ApiKeySetup.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { ExternalLink, Key, Camera, ArrowLeft, Lock, Shield, Loader2 } from 'lucide-react';
-import { hasEncryptedApiKey, loadApiKeyEncrypted, setApiKeyEncrypted, hasMasterPassword } from '../services/geminiService';
-import { hashPassword } from '../utils/crypto';
+import { useApiKeySetupState } from '../hooks/useApiKeySetupState';
 
 interface ApiKeySetupProps {
   onComplete: (apiKey: string) => void;
@@ -9,103 +8,24 @@ interface ApiKeySetupProps {
   onImportPdf?: () => void;
 }
 
-type SetupMode = 'check' | 'unlock' | 'new';
-
 const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onComplete, onCancel, onImportPdf }) => {
-  const [mode, setMode] = useState<SetupMode>('check');
-  const [apiKey, setApiKey] = useState('');
-  const [masterPassword, setMasterPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
-
-  const isValidKey = apiKey.trim().startsWith('AIza') && apiKey.trim().length >= 39;
-  const isValidPassword = masterPassword.length >= 4;
-  const passwordsMatch = masterPassword === confirmPassword;
-
-  // 初期化: 暗号化されたキーがあるかチェック
-  useEffect(() => {
-    if (hasEncryptedApiKey()) {
-      setMode('unlock');
-    } else {
-      setMode('new');
-    }
-  }, []);
-
-  // アンロック処理
-  const handleUnlock = async () => {
-    if (!masterPassword) {
-      setError('パスワードを入力してください');
-      return;
-    }
-
-    setLoading(true);
-    setError('');
-
-    try {
-      const success = await loadApiKeyEncrypted(masterPassword);
-      if (success) {
-        // 復号成功 - getApiKey()で取得できるようになる
-        const { getApiKey } = await import('../services/geminiService');
-        const key = getApiKey();
-        if (key) {
-          onComplete(key);
-        } else {
-          setError('キーの読み込みに失敗しました');
-        }
-      } else {
-        setError('パスワードが違います');
-      }
-    } catch (e: any) {
-      setError('復号に失敗しました');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // 新規設定処理
-  const handleSubmit = async () => {
-    if (!isValidKey) {
-      setError('有効なAPIキーを入力してください');
-      return;
-    }
-    if (!isValidPassword) {
-      setError('パスワードは4文字以上で入力してください');
-      return;
-    }
-    if (!passwordsMatch) {
-      setError('パスワードが一致しません');
-      return;
-    }
-
-    setLoading(true);
-    setError('');
-
-    try {
-      // マスターパスワードのハッシュを保存
-      const hash = await hashPassword(masterPassword);
-      localStorage.setItem('gaspm_master_hash', hash);
-
-      // APIキーを暗号化して保存
-      await setApiKeyEncrypted(apiKey.trim(), masterPassword);
-      onComplete(apiKey.trim());
-    } catch (e: any) {
-      setError('保存に失敗しました: ' + e.message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // 新規設定に切り替え（暗号化キーを破棄）
-  const handleResetKey = () => {
-    if (window.confirm('保存されたAPIキーを削除しますか？新しいキーを設定できます。')) {
-      localStorage.removeItem('gaspm_encrypted_api_key');
-      localStorage.removeItem('gaspm_master_hash');
-      setMode('new');
-      setMasterPassword('');
-      setError('');
-    }
-  };
+  const {
+    mode,
+    apiKey,
+    masterPassword,
+    confirmPassword,
+    error,
+    loading,
+    isValidKey,
+    isValidPassword,
+    passwordsMatch,
+    setApiKey,
+    setMasterPassword,
+    setConfirmPassword,
+    handleUnlock,
+    handleSubmit,
+    handleResetKey,
+  } = useApiKeySetupState();
 
   if (mode === 'check') {
     return (
@@ -163,7 +83,7 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onComplete, onCancel, onImpor
                       type="password"
                       value={masterPassword}
                       onChange={(e) => setMasterPassword(e.target.value)}
-                      onKeyDown={(e) => e.key === 'Enter' && handleUnlock()}
+                      onKeyDown={(e) => e.key === 'Enter' && handleUnlock(onComplete)}
                       placeholder="マスターパスワード"
                       className="flex-1 bg-slate-900 border border-slate-600 rounded-lg px-3 py-3 text-white placeholder-slate-500 focus:outline-none focus:border-blue-500 text-sm"
                       autoFocus
@@ -173,7 +93,7 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onComplete, onCancel, onImpor
                     <p className="text-red-400 text-xs text-center">{error}</p>
                   )}
                   <button
-                    onClick={handleUnlock}
+                    onClick={() => handleUnlock(onComplete)}
                     disabled={loading || !masterPassword}
                     className="w-full bg-blue-500 hover:bg-blue-400 disabled:bg-slate-700 disabled:text-slate-500 text-white font-bold py-3 rounded-xl transition-all flex items-center justify-center gap-2"
                   >
@@ -313,7 +233,7 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onComplete, onCancel, onImpor
         <div className="p-4 border-t border-slate-800 bg-slate-900">
           <div className="max-w-md mx-auto">
             <button
-              onClick={handleSubmit}
+              onClick={() => handleSubmit(onComplete)}
               disabled={!isValidKey || !isValidPassword || !passwordsMatch || loading}
               className="w-full bg-blue-500 hover:bg-blue-400 disabled:bg-slate-700 disabled:text-slate-500 text-white font-bold py-3 rounded-xl transition-all flex items-center justify-center gap-2"
             >

--- a/components/CodebaseHealthDashboard.tsx
+++ b/components/CodebaseHealthDashboard.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
   ArrowLeft, GitBranch, CheckCircle, AlertTriangle, RefreshCw,
   ChevronDown, ChevronRight, Scale, AlertCircle, PackageX, MoreVertical, ExternalLink,
   Network, Layers, Zap, FileCode, Copy, Check, ArrowRight, TreePine, Folder, GitCompare
 } from 'lucide-react';
 import codebaseStats from '../src/generated/codebase-stats.json';
+import { useDashboardState, useCopyState, useExpandedState } from '../hooks/useDashboardState';
 
 interface CodebaseHealthDashboardProps {
   lang: 'en' | 'ja';
@@ -189,17 +190,11 @@ const EFFORT_LABELS: Record<string, { label: string; color: string }> = {
 
 // コピーボタンコンポーネント
 const CopyButton: React.FC<{ text: string; label?: string }> = ({ text, label = '📋 指示をコピー' }) => {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+  const { copied, handleCopy } = useCopyState();
 
   return (
     <button
-      onClick={handleCopy}
+      onClick={() => handleCopy(text)}
       className={`text-xs px-3 py-1.5 rounded flex items-center gap-1 transition-colors ${
         copied ? 'bg-green-600 text-white' : 'bg-blue-600 text-white hover:bg-blue-700'
       }`}
@@ -212,7 +207,7 @@ const CopyButton: React.FC<{ text: string; label?: string }> = ({ text, label = 
 
 // 改善提案カード
 const SuggestionCard: React.FC<{ suggestion: any; lang: 'en' | 'ja' }> = ({ suggestion, lang }) => {
-  const [expanded, setExpanded] = useState(false);
+  const { expanded, toggle } = useExpandedState();
   const categoryStyle = CATEGORY_COLORS[suggestion.category] || CATEGORY_COLORS.maintainability;
   const effortStyle = EFFORT_LABELS[suggestion.effort] || EFFORT_LABELS.medium;
   const priorityStyle = PRIORITY_STYLES[suggestion.priority as Priority] || PRIORITY_STYLES.low;
@@ -248,7 +243,7 @@ const SuggestionCard: React.FC<{ suggestion: any; lang: 'en' | 'ja' }> = ({ sugg
         <div className="flex flex-col gap-2">
           <CopyButton text={suggestion.prompt} />
           <button
-            onClick={() => setExpanded(!expanded)}
+            onClick={toggle}
             className="text-xs text-gray-600 hover:text-gray-900"
           >
             {expanded ? '詳細を隠す' : '詳細を見る'}
@@ -546,31 +541,17 @@ const SimilarModuleCard: React.FC<{ pair: any }> = ({ pair }) => {
 };
 
 const CodebaseHealthDashboard: React.FC<CodebaseHealthDashboardProps> = ({ lang, onClose }) => {
-  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['tasks']));
-  const [isLoading, setIsLoading] = useState(true);
-  const [showMenu, setShowMenu] = useState(false);
-  const [healthChecks, setHealthChecks] = useState<any[]>([]);
+  const {
+    expandedSections,
+    isLoading,
+    showMenu,
+    healthChecks,
+    toggle,
+    setShowMenu,
+    runAnalysis,
+  } = useDashboardState();
 
   const t = (ja: string, en: string) => lang === 'ja' ? ja : en;
-  const toggle = (s: string) => setExpandedSections(prev => {
-    const next = new Set(prev);
-    next.has(s) ? next.delete(s) : next.add(s);
-    return next;
-  });
-
-  useEffect(() => {
-    setHealthChecks((codebaseStats as any).health || []);
-    setIsLoading(false);
-  }, []);
-
-  const runAnalysis = async () => {
-    setIsLoading(true);
-    try {
-      const res = await fetch('/api/analyze');
-      if ((await res.json()).success) window.location.reload();
-      else setIsLoading(false);
-    } catch { setIsLoading(false); }
-  };
 
   const tasks = codebaseStats.tasks?.filter((t: any) => t.status === 'todo')
     .sort((a: any, b: any) => ({ high: 0, medium: 1, low: 2 }[a.priority as Priority] ?? 2) - ({ high: 0, medium: 1, low: 2 }[b.priority as Priority] ?? 2)) || [];

--- a/components/GitHubSyncPanel.tsx
+++ b/components/GitHubSyncPanel.tsx
@@ -1,154 +1,29 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Github, Upload, Download, Check, X, AlertCircle, ExternalLink, Key, RefreshCw } from 'lucide-react';
-import {
-  getGitHubToken,
-  setGitHubToken,
-  clearGitHubToken,
-  hasGitHubToken,
-  validateGitHubToken,
-  fetchLearnedSettings,
-  pushLearnedSettings,
-  buildLearnedSettingsFromLocal,
-  getSyncStatus,
-  SyncStatus
-} from '../services/githubSync';
-import { LearnedSettings } from '../types';
+import { useGitHubSyncState } from '../hooks/useGitHubSyncState';
 
 interface GitHubSyncPanelProps {
   onClose: () => void;
 }
 
-type Step = 'setup' | 'connected' | 'syncing';
-
 const GitHubSyncPanel: React.FC<GitHubSyncPanelProps> = ({ onClose }) => {
-  const [step, setStep] = useState<Step>('setup');
-  const [token, setToken] = useState('');
-  const [username, setUsername] = useState<string | null>(null);
-  const [isValidating, setIsValidating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null);
-  const [isSyncing, setIsSyncing] = useState(false);
-  const [lastCommitUrl, setLastCommitUrl] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
-
-  // 初期化: トークンがあれば接続状態を復元
-  useEffect(() => {
-    const init = async () => {
-      if (hasGitHubToken()) {
-        const savedToken = getGitHubToken()!;
-        const result = await validateGitHubToken(savedToken);
-        if (result.valid) {
-          setUsername(result.username || null);
-          setStep('connected');
-          // ステータスを取得
-          const status = await getSyncStatus(savedToken);
-          setSyncStatus(status);
-        } else {
-          clearGitHubToken();
-        }
-      }
-    };
-    init();
-  }, []);
-
-  // トークン検証
-  const handleValidateToken = async () => {
-    if (!token.trim()) return;
-
-    setIsValidating(true);
-    setError(null);
-
-    const result = await validateGitHubToken(token.trim());
-
-    if (result.valid) {
-      setGitHubToken(token.trim());
-      setUsername(result.username || null);
-      setStep('connected');
-      // ステータスを取得
-      const status = await getSyncStatus(token.trim());
-      setSyncStatus(status);
-    } else {
-      setError(result.error || 'トークンの検証に失敗しました');
-    }
-
-    setIsValidating(false);
-  };
-
-  // ログアウト
-  const handleDisconnect = () => {
-    clearGitHubToken();
-    setUsername(null);
-    setToken('');
-    setSyncStatus(null);
-    setStep('setup');
-  };
-
-  // プッシュ
-  const handlePush = async () => {
-    const savedToken = getGitHubToken();
-    if (!savedToken) return;
-
-    setIsSyncing(true);
-    setError(null);
-    setSuccessMessage(null);
-
-    try {
-      const settings = await buildLearnedSettingsFromLocal();
-      const result = await pushLearnedSettings(savedToken, settings);
-
-      if (result.success) {
-        setLastCommitUrl(result.commitUrl || null);
-        setSuccessMessage('学習データをGitHubにプッシュしました');
-        // ステータス更新
-        const status = await getSyncStatus(savedToken);
-        setSyncStatus(status);
-      } else {
-        setError(result.error || 'プッシュに失敗しました');
-      }
-    } catch (e: any) {
-      setError(e.message || 'プッシュ中にエラーが発生しました');
-    }
-
-    setIsSyncing(false);
-  };
-
-  // プル
-  const handlePull = async () => {
-    const savedToken = getGitHubToken();
-    if (!savedToken) return;
-
-    setIsSyncing(true);
-    setError(null);
-    setSuccessMessage(null);
-
-    try {
-      const settings = await fetchLearnedSettings(savedToken);
-      if (settings) {
-        // TODO: ローカルにマージする処理
-        setSuccessMessage(`GitHubから設定を取得しました (v${settings.version})`);
-        // ステータス更新
-        const status = await getSyncStatus(savedToken);
-        setSyncStatus(status);
-      } else {
-        setError('設定の取得に失敗しました');
-      }
-    } catch (e: any) {
-      setError(e.message || 'プル中にエラーが発生しました');
-    }
-
-    setIsSyncing(false);
-  };
-
-  // ステータス更新
-  const handleRefreshStatus = async () => {
-    const savedToken = getGitHubToken();
-    if (!savedToken) return;
-
-    setIsSyncing(true);
-    const status = await getSyncStatus(savedToken);
-    setSyncStatus(status);
-    setIsSyncing(false);
-  };
+  const {
+    step,
+    token,
+    username,
+    isValidating,
+    error,
+    syncStatus,
+    isSyncing,
+    lastCommitUrl,
+    successMessage,
+    setToken,
+    handleValidateToken,
+    handleDisconnect,
+    handlePush,
+    handlePull,
+    handleRefreshStatus,
+  } = useGitHubSyncState();
 
   return (
     <div className="fixed inset-0 bg-black/60 z-[200] flex items-center justify-center p-4">

--- a/components/ModelValidation.tsx
+++ b/components/ModelValidation.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { ArrowLeft, Cpu, Loader2, CheckCircle, XCircle, AlertTriangle, Ban, Search, Shield, Fingerprint } from 'lucide-react';
-import { validateAllModels, AVAILABLE_MODELS, ModelType, ModelStatus, ModelAvailability, getSelectedModel, setSelectedModel, getBestAvailableModel, setTrustedSession } from '../services/geminiService';
-import { isBiometricAvailable, hasRegisteredPasskey, registerPasskey, authenticateWithPasskey, removePasskey } from '../services/webAuthnService';
+import { ModelStatus } from '../services/geminiService';
+import { useModelValidationState } from '../hooks/useModelValidationState';
+import { useBiometricAuth } from '../hooks/useBiometricAuth';
 
 interface ModelValidationProps {
   apiKey: string;
@@ -10,115 +11,31 @@ interface ModelValidationProps {
 }
 
 const ModelValidation: React.FC<ModelValidationProps> = ({ apiKey, onComplete, onBack }) => {
-  const [selectedModel, setSelectedModelState] = useState<ModelType>(getSelectedModel());
-  const [isValidating, setIsValidating] = useState(false);
-  const [modelAvailabilities, setModelAvailabilities] = useState<ModelAvailability[]>([]);
-  const [keyError, setKeyError] = useState<string | null>(null);
-  const [trustSession, setTrustSession] = useState(true);
+  const {
+    selectedModel,
+    isValidating,
+    modelAvailabilities,
+    keyError,
+    trustSession,
+    hasAnyAvailable,
+    setTrustSession,
+    validateModels,
+    handleModelChange,
+    handleSubmit,
+    getStatusText,
+  } = useModelValidationState();
 
-  // 生体認証関連
-  const [biometricSupported, setBiometricSupported] = useState(false);
-  const [hasPasskey, setHasPasskey] = useState(false);
-  const [isAuthenticating, setIsAuthenticating] = useState(false);
-  const [registerBiometric, setRegisterBiometric] = useState(true);
-  const [biometricError, setBiometricError] = useState<string | null>(null);
-
-  // 生体認証の可否をチェック
-  useEffect(() => {
-    const checkBiometric = async () => {
-      const available = await isBiometricAvailable();
-      setBiometricSupported(available);
-      if (available) {
-        setHasPasskey(hasRegisteredPasskey());
-      }
-    };
-    checkBiometric();
-  }, []);
-
-  const validateModels = async () => {
-    setIsValidating(true);
-    setKeyError(null);
-    setModelAvailabilities(AVAILABLE_MODELS.map(m => ({ ...m, status: 'checking' as ModelStatus })));
-
-    const results = await validateAllModels(apiKey, (modelId, status, error) => {
-      setModelAvailabilities(prev =>
-        prev.map(m => m.id === modelId ? { ...m, status, error } : m)
-      );
-    });
-
-    setModelAvailabilities(results);
-    setIsValidating(false);
-
-    const allInvalid = results.every(r => r.error?.includes('無効'));
-    if (allInvalid) {
-      setKeyError('APIキーが無効です');
-    }
-
-    const bestModel = getBestAvailableModel(results);
-    if (bestModel) {
-      setSelectedModelState(bestModel);
-    }
-  };
-
-  // 生体認証でログイン
-  const handleBiometricLogin = async () => {
-    setIsAuthenticating(true);
-    setBiometricError(null);
-
-    const result = await authenticateWithPasskey();
-
-    if (result.success && result.apiKey) {
-      setTrustedSession(true);
-      onComplete(result.apiKey);
-    } else {
-      setBiometricError(result.error || '認証に失敗しました');
-    }
-
-    setIsAuthenticating(false);
-  };
-
-  // パスキーを削除
-  const handleRemovePasskey = () => {
-    if (confirm('登録済みの生体認証を削除しますか？')) {
-      removePasskey();
-      setHasPasskey(false);
-    }
-  };
-
-  const handleSubmit = async () => {
-    const selectedAvailability = modelAvailabilities.find(m => m.id === selectedModel);
-
-    if (!selectedAvailability || selectedAvailability.status !== 'available') {
-      const bestModel = getBestAvailableModel(modelAvailabilities);
-      if (bestModel) {
-        setSelectedModel(bestModel);
-      } else {
-        return;
-      }
-    } else {
-      setSelectedModel(selectedModel);
-    }
-
-    // 生体認証を登録する場合
-    if (biometricSupported && registerBiometric && !hasPasskey) {
-      const result = await registerPasskey(apiKey);
-      if (result.success) {
-        setHasPasskey(true);
-      } else {
-        console.warn('Passkey registration failed:', result.error);
-      }
-    }
-
-    setTrustedSession(trustSession);
-    onComplete(apiKey);
-  };
-
-  const handleModelChange = (model: ModelType) => {
-    const availability = modelAvailabilities.find(m => m.id === model);
-    if (availability?.status === 'available') {
-      setSelectedModelState(model);
-    }
-  };
+  const {
+    biometricSupported,
+    hasPasskey,
+    isAuthenticating,
+    registerBiometric,
+    biometricError,
+    setRegisterBiometric,
+    handleBiometricLogin,
+    handleRemovePasskey,
+    handleRegisterPasskey,
+  } = useBiometricAuth();
 
   const getStatusIcon = (status: ModelStatus) => {
     switch (status) {
@@ -135,22 +52,13 @@ const ModelValidation: React.FC<ModelValidationProps> = ({ apiKey, onComplete, o
     }
   };
 
-  const getStatusText = (status: ModelStatus, error?: string) => {
-    switch (status) {
-      case 'available':
-        return '利用可能';
-      case 'quota_exceeded':
-        return '制限超過';
-      case 'unavailable':
-        return error || '利用不可';
-      case 'checking':
-        return '確認中...';
-      default:
-        return error || 'エラー';
-    }
+  const onSubmit = async () => {
+    await handleSubmit(
+      apiKey,
+      onComplete,
+      async () => handleRegisterPasskey(apiKey)
+    );
   };
-
-  const hasAnyAvailable = modelAvailabilities.some(m => m.status === 'available');
 
   return (
     <div className="fixed inset-0 bg-slate-900 z-[130] flex flex-col">
@@ -179,7 +87,7 @@ const ModelValidation: React.FC<ModelValidationProps> = ({ apiKey, onComplete, o
 
             {/* 検証ボタン */}
             <button
-              onClick={validateModels}
+              onClick={() => validateModels(apiKey)}
               disabled={isValidating}
               className="w-full flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white font-medium py-3 rounded-xl transition-all text-sm mb-4"
             >
@@ -289,7 +197,7 @@ const ModelValidation: React.FC<ModelValidationProps> = ({ apiKey, onComplete, o
                   <div className="h-px bg-slate-700"></div>
                   <div className="space-y-2">
                     <button
-                      onClick={handleBiometricLogin}
+                      onClick={() => handleBiometricLogin(onComplete)}
                       disabled={isAuthenticating}
                       className="w-full bg-purple-500 hover:bg-purple-400 disabled:bg-purple-600 text-white font-bold py-3 rounded-xl transition-all flex items-center justify-center gap-2"
                     >
@@ -354,7 +262,7 @@ const ModelValidation: React.FC<ModelValidationProps> = ({ apiKey, onComplete, o
       <div className="p-4 border-t border-slate-800 bg-slate-900">
         <div className="max-w-md mx-auto">
           <button
-            onClick={handleSubmit}
+            onClick={onSubmit}
             disabled={isValidating || !hasAnyAvailable}
             className="w-full bg-blue-500 hover:bg-blue-400 disabled:bg-slate-700 disabled:text-slate-500 text-white font-bold py-3 rounded-xl transition-all flex items-center justify-center gap-2"
           >

--- a/components/PreviewView.tsx
+++ b/components/PreviewView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React from 'react';
 import { Loader2, Download, Printer, AlertCircle, Home, X, Database, FileArchive, Save, StopCircle } from 'lucide-react';
 import { TRANS } from '../utils/translations';
 import { PhotoRecord, ProcessingStats, AppMode, AIAnalysisResult, LogEntry } from '../types';
@@ -7,10 +7,7 @@ import ConsolePanel from './ConsolePanel';
 import SessionHistoryPanel from './SessionHistoryPanel';
 import { ReorderModeView, PreviewToolsMenu } from './PreviewView/index';
 import { useReorderMode } from '../hooks/useReorderMode';
-import { generateZip } from '../utils/zipGenerator';
-
-declare const saveAs: any;
-const A4_WIDTH_PX = 794;
+import { usePreviewViewState } from '../hooks/usePreviewViewState';
 
 interface PreviewViewProps {
   lang: 'en' | 'ja';
@@ -54,70 +51,24 @@ const PreviewView: React.FC<PreviewViewProps> = ({
   onOpenMasterEditor, onReorderPhotos, onOpenStationReplace, onApplyAliases, onOpenGitHubSync
 }) => {
   const txt = TRANS[lang];
-  const [scale, setScale] = useState(1);
-  const [isFitMode, setIsFitMode] = useState(true);
-  const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
-  const [isGeneratingZip, setIsGeneratingZip] = useState(false);
-  const [showConsole, setShowConsole] = useState(true);
-  const [photosPerPage, setPhotosPerPage] = useState<2 | 3>(initialLayout);
-  const [showHistoryPanel, setShowHistoryPanel] = useState(false);
-  const previewContainerRef = useRef<HTMLDivElement>(null);
-
   const reorder = useReorderMode(photos, onReorderPhotos);
 
-  useEffect(() => { setPhotosPerPage(initialLayout); }, [initialLayout]);
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (!previewContainerRef.current) return;
-      const containerWidth = previewContainerRef.current.clientWidth;
-      const availableWidth = containerWidth - 32;
-      setScale(isFitMode && availableWidth < A4_WIDTH_PX ? availableWidth / A4_WIDTH_PX : 1);
-    };
-    window.addEventListener('resize', handleResize);
-    handleResize();
-    return () => window.removeEventListener('resize', handleResize);
-  }, [isFitMode]);
-
-  const handleDownloadPDF = async () => {
-    setIsGeneratingPdf(true);
-    try {
-      const { generatePdfWithImages } = await import('../utils/pdfGenerator');
-      const pdfBlob = await generatePdfWithImages(photos, photosPerPage, '工事写真帳');
-      const filename = `construction_album_${new Date().toISOString().slice(0, 10)}.pdf`;
-      saveAs(pdfBlob, filename);
-      window.open(URL.createObjectURL(pdfBlob), '_blank');
-    } catch (err) {
-      console.error('PDF generation error:', err);
-      alert(txt.pdfError);
-    } finally {
-      setIsGeneratingPdf(false);
-    }
-  };
-
-  const handleDownloadZip = async () => {
-    if (photos.length === 0) return;
-    setIsGeneratingZip(true);
-    try {
-      const blob = await generateZip(photos);
-      saveAs(blob, `electronic_delivery_${new Date().toISOString().slice(0, 10)}.zip`);
-    } catch (e) {
-      console.error(e);
-      alert("Failed to generate ZIP.");
-    } finally {
-      setIsGeneratingZip(false);
-    }
-  };
-
-  const handleAutoPairClick = () => {
-    if (photosPerPage !== 2) setPhotosPerPage(2);
-    onAutoPair();
-  };
-
-  const handleManualPairClick = () => {
-    setPhotosPerPage(2);
-    onManualPair();
-  };
+  const {
+    scale,
+    photosPerPage,
+    isGeneratingPdf,
+    isGeneratingZip,
+    showConsole,
+    showHistoryPanel,
+    previewContainerRef,
+    setPhotosPerPage,
+    setShowConsole,
+    setShowHistoryPanel,
+    handleDownloadPDF,
+    handleDownloadZip,
+    handleAutoPairClick,
+    handleManualPairClick,
+  } = usePreviewViewState(initialLayout);
 
   const hasPhotosWithBoard = photos.some(p => p.analysis?.hasBoard);
 
@@ -171,11 +122,11 @@ const PreviewView: React.FC<PreviewViewProps> = ({
               <Download className="w-4 h-4" /> <span className="hidden lg:inline">{txt.exportExcel}</span>
             </button>
             {appMode === 'construction' && (
-              <button onClick={handleDownloadZip} disabled={isGeneratingZip || isProcessing} className="p-2 md:px-3 md:py-2 bg-blue-500 hover:bg-blue-600 rounded text-sm font-bold text-white shadow-sm flex items-center gap-1" title="XML/ZIP">
+              <button onClick={() => handleDownloadZip(photos)} disabled={isGeneratingZip || isProcessing} className="p-2 md:px-3 md:py-2 bg-blue-500 hover:bg-blue-600 rounded text-sm font-bold text-white shadow-sm flex items-center gap-1" title="XML/ZIP">
                 {isGeneratingZip ? <Loader2 className="w-4 h-4 animate-spin" /> : <FileArchive className="w-4 h-4" />} <span className="hidden lg:inline">ZIP</span>
               </button>
             )}
-            <button onClick={handleDownloadPDF} disabled={isGeneratingPdf || isProcessing} className="p-2 md:px-3 md:py-2 bg-red-600 hover:bg-red-700 rounded text-sm font-bold text-white shadow-sm flex items-center gap-1" title={txt.exportPDF}>
+            <button onClick={() => handleDownloadPDF(photos, txt)} disabled={isGeneratingPdf || isProcessing} className="p-2 md:px-3 md:py-2 bg-red-600 hover:bg-red-700 rounded text-sm font-bold text-white shadow-sm flex items-center gap-1" title={txt.exportPDF}>
               {isGeneratingPdf ? <Loader2 className="w-4 h-4 animate-spin" /> : <Printer className="w-4 h-4" />} <span className="hidden lg:inline">PDF</span>
             </button>
           </div>
@@ -184,8 +135,8 @@ const PreviewView: React.FC<PreviewViewProps> = ({
             <PreviewToolsMenu
               lang={lang}
               isProcessing={isProcessing}
-              onAutoPair={handleAutoPairClick}
-              onManualPair={handleManualPairClick}
+              onAutoPair={() => handleAutoPairClick(onAutoPair)}
+              onManualPair={() => handleManualPairClick(onManualPair)}
               onEnterReorderMode={reorder.enterReorderMode}
               onRefine={onRefine}
               onShowHistory={() => setShowHistoryPanel(true)}

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -15,3 +15,11 @@ export { useStartProcessingFlow } from './useStartProcessingFlow';
 export { useNormalizationHandlers } from './useNormalizationHandlers';
 export { usePhotoManagement } from './usePhotoManagement';
 export { useProjectHandlers } from './useProjectHandlers';
+
+// 新規追加フック
+export { useApiKeySetupState } from './useApiKeySetupState';
+export { useDashboardState, useCopyState, useExpandedState } from './useDashboardState';
+export { useGitHubSyncState } from './useGitHubSyncState';
+export { useModelValidationState } from './useModelValidationState';
+export { useBiometricAuth } from './useBiometricAuth';
+export { usePreviewViewState } from './usePreviewViewState';

--- a/hooks/useApiKeySetupState.ts
+++ b/hooks/useApiKeySetupState.ts
@@ -1,0 +1,140 @@
+import { useState, useEffect, useCallback } from 'react';
+import { hasEncryptedApiKey, loadApiKeyEncrypted, setApiKeyEncrypted } from '../services/geminiService';
+import { hashPassword } from '../utils/crypto';
+
+type SetupMode = 'check' | 'unlock' | 'new';
+
+interface ApiKeySetupState {
+  mode: SetupMode;
+  apiKey: string;
+  masterPassword: string;
+  confirmPassword: string;
+  error: string;
+  loading: boolean;
+}
+
+interface ApiKeySetupActions {
+  setApiKey: (value: string) => void;
+  setMasterPassword: (value: string) => void;
+  setConfirmPassword: (value: string) => void;
+  handleUnlock: (onComplete: (key: string) => void) => Promise<void>;
+  handleSubmit: (onComplete: (key: string) => void) => Promise<void>;
+  handleResetKey: () => void;
+}
+
+interface ApiKeySetupValidation {
+  isValidKey: boolean;
+  isValidPassword: boolean;
+  passwordsMatch: boolean;
+}
+
+export function useApiKeySetupState(): ApiKeySetupState & ApiKeySetupActions & ApiKeySetupValidation {
+  const [mode, setMode] = useState<SetupMode>('check');
+  const [apiKey, setApiKey] = useState('');
+  const [masterPassword, setMasterPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const isValidKey = apiKey.trim().startsWith('AIza') && apiKey.trim().length >= 39;
+  const isValidPassword = masterPassword.length >= 4;
+  const passwordsMatch = masterPassword === confirmPassword;
+
+  // 初期化: 暗号化されたキーがあるかチェック
+  useEffect(() => {
+    if (hasEncryptedApiKey()) {
+      setMode('unlock');
+    } else {
+      setMode('new');
+    }
+  }, []);
+
+  // アンロック処理
+  const handleUnlock = useCallback(async (onComplete: (key: string) => void) => {
+    if (!masterPassword) {
+      setError('パスワードを入力してください');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      const success = await loadApiKeyEncrypted(masterPassword);
+      if (success) {
+        const { getApiKey } = await import('../services/geminiService');
+        const key = getApiKey();
+        if (key) {
+          onComplete(key);
+        } else {
+          setError('キーの読み込みに失敗しました');
+        }
+      } else {
+        setError('パスワードが違います');
+      }
+    } catch {
+      setError('復号に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, [masterPassword]);
+
+  // 新規設定処理
+  const handleSubmit = useCallback(async (onComplete: (key: string) => void) => {
+    if (!isValidKey) {
+      setError('有効なAPIキーを入力してください');
+      return;
+    }
+    if (!isValidPassword) {
+      setError('パスワードは4文字以上で入力してください');
+      return;
+    }
+    if (!passwordsMatch) {
+      setError('パスワードが一致しません');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      const hash = await hashPassword(masterPassword);
+      localStorage.setItem('gaspm_master_hash', hash);
+      await setApiKeyEncrypted(apiKey.trim(), masterPassword);
+      onComplete(apiKey.trim());
+    } catch (e: any) {
+      setError('保存に失敗しました: ' + e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [apiKey, masterPassword, isValidKey, isValidPassword, passwordsMatch]);
+
+  // 新規設定に切り替え（暗号化キーを破棄）
+  const handleResetKey = useCallback(() => {
+    if (window.confirm('保存されたAPIキーを削除しますか？新しいキーを設定できます。')) {
+      localStorage.removeItem('gaspm_encrypted_api_key');
+      localStorage.removeItem('gaspm_master_hash');
+      setMode('new');
+      setMasterPassword('');
+      setError('');
+    }
+  }, []);
+
+  return {
+    mode,
+    apiKey,
+    masterPassword,
+    confirmPassword,
+    error,
+    loading,
+    isValidKey,
+    isValidPassword,
+    passwordsMatch,
+    setApiKey,
+    setMasterPassword,
+    setConfirmPassword,
+    handleUnlock,
+    handleSubmit,
+    handleResetKey,
+  };
+}

--- a/hooks/useBiometricAuth.ts
+++ b/hooks/useBiometricAuth.ts
@@ -1,0 +1,93 @@
+import { useState, useEffect, useCallback } from 'react';
+import { setTrustedSession } from '../services/geminiService';
+import {
+  isBiometricAvailable,
+  hasRegisteredPasskey,
+  registerPasskey,
+  authenticateWithPasskey,
+  removePasskey
+} from '../services/webAuthnService';
+
+interface BiometricAuthState {
+  biometricSupported: boolean;
+  hasPasskey: boolean;
+  isAuthenticating: boolean;
+  registerBiometric: boolean;
+  biometricError: string | null;
+}
+
+interface BiometricAuthActions {
+  setRegisterBiometric: (value: boolean) => void;
+  handleBiometricLogin: (onComplete: (apiKey: string) => void) => Promise<void>;
+  handleRemovePasskey: () => void;
+  handleRegisterPasskey: (apiKey: string) => Promise<void>;
+}
+
+export function useBiometricAuth(): BiometricAuthState & BiometricAuthActions {
+  const [biometricSupported, setBiometricSupported] = useState(false);
+  const [hasPasskey, setHasPasskey] = useState(false);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [registerBiometric, setRegisterBiometric] = useState(true);
+  const [biometricError, setBiometricError] = useState<string | null>(null);
+
+  // 生体認証の可否をチェック
+  useEffect(() => {
+    const checkBiometric = async () => {
+      const available = await isBiometricAvailable();
+      setBiometricSupported(available);
+      if (available) {
+        setHasPasskey(hasRegisteredPasskey());
+      }
+    };
+    checkBiometric();
+  }, []);
+
+  // 生体認証でログイン
+  const handleBiometricLogin = useCallback(async (onComplete: (apiKey: string) => void) => {
+    setIsAuthenticating(true);
+    setBiometricError(null);
+
+    const result = await authenticateWithPasskey();
+
+    if (result.success && result.apiKey) {
+      setTrustedSession(true);
+      onComplete(result.apiKey);
+    } else {
+      setBiometricError(result.error || '認証に失敗しました');
+    }
+
+    setIsAuthenticating(false);
+  }, []);
+
+  // パスキーを削除
+  const handleRemovePasskey = useCallback(() => {
+    if (confirm('登録済みの生体認証を削除しますか？')) {
+      removePasskey();
+      setHasPasskey(false);
+    }
+  }, []);
+
+  // パスキーを登録
+  const handleRegisterPasskey = useCallback(async (apiKey: string) => {
+    if (biometricSupported && registerBiometric && !hasPasskey) {
+      const result = await registerPasskey(apiKey);
+      if (result.success) {
+        setHasPasskey(true);
+      } else {
+        console.warn('Passkey registration failed:', result.error);
+      }
+    }
+  }, [biometricSupported, registerBiometric, hasPasskey]);
+
+  return {
+    biometricSupported,
+    hasPasskey,
+    isAuthenticating,
+    registerBiometric,
+    biometricError,
+    setRegisterBiometric,
+    handleBiometricLogin,
+    handleRemovePasskey,
+    handleRegisterPasskey,
+  };
+}

--- a/hooks/useDashboardState.ts
+++ b/hooks/useDashboardState.ts
@@ -1,0 +1,79 @@
+import { useState, useEffect, useCallback } from 'react';
+import codebaseStats from '../src/generated/codebase-stats.json';
+
+interface DashboardState {
+  expandedSections: Set<string>;
+  isLoading: boolean;
+  showMenu: boolean;
+  healthChecks: any[];
+}
+
+interface DashboardActions {
+  toggle: (section: string) => void;
+  setShowMenu: (value: boolean) => void;
+  runAnalysis: () => Promise<void>;
+}
+
+export function useDashboardState(): DashboardState & DashboardActions {
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['tasks']));
+  const [isLoading, setIsLoading] = useState(true);
+  const [showMenu, setShowMenu] = useState(false);
+  const [healthChecks, setHealthChecks] = useState<any[]>([]);
+
+  useEffect(() => {
+    setHealthChecks((codebaseStats as any).health || []);
+    setIsLoading(false);
+  }, []);
+
+  const toggle = useCallback((section: string) => {
+    setExpandedSections(prev => {
+      const next = new Set(prev);
+      next.has(section) ? next.delete(section) : next.add(section);
+      return next;
+    });
+  }, []);
+
+  const runAnalysis = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch('/api/analyze');
+      if ((await res.json()).success) {
+        window.location.reload();
+      } else {
+        setIsLoading(false);
+      }
+    } catch {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return {
+    expandedSections,
+    isLoading,
+    showMenu,
+    healthChecks,
+    toggle,
+    setShowMenu,
+    runAnalysis,
+  };
+}
+
+// CopyButton用のフック
+export function useCopyState() {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async (text: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, []);
+
+  return { copied, handleCopy };
+}
+
+// SuggestionCard用のフック
+export function useExpandedState(initial = false) {
+  const [expanded, setExpanded] = useState(initial);
+  const toggle = useCallback(() => setExpanded(prev => !prev), []);
+  return { expanded, toggle };
+}

--- a/hooks/useGitHubSyncState.ts
+++ b/hooks/useGitHubSyncState.ts
@@ -1,0 +1,180 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  getGitHubToken,
+  setGitHubToken,
+  clearGitHubToken,
+  hasGitHubToken,
+  validateGitHubToken,
+  fetchLearnedSettings,
+  pushLearnedSettings,
+  buildLearnedSettingsFromLocal,
+  getSyncStatus,
+  SyncStatus
+} from '../services/githubSync';
+
+type Step = 'setup' | 'connected' | 'syncing';
+
+interface GitHubSyncState {
+  step: Step;
+  token: string;
+  username: string | null;
+  isValidating: boolean;
+  error: string | null;
+  syncStatus: SyncStatus | null;
+  isSyncing: boolean;
+  lastCommitUrl: string | null;
+  successMessage: string | null;
+}
+
+interface GitHubSyncActions {
+  setToken: (value: string) => void;
+  handleValidateToken: () => Promise<void>;
+  handleDisconnect: () => void;
+  handlePush: () => Promise<void>;
+  handlePull: () => Promise<void>;
+  handleRefreshStatus: () => Promise<void>;
+}
+
+export function useGitHubSyncState(): GitHubSyncState & GitHubSyncActions {
+  const [step, setStep] = useState<Step>('setup');
+  const [token, setToken] = useState('');
+  const [username, setUsername] = useState<string | null>(null);
+  const [isValidating, setIsValidating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const [lastCommitUrl, setLastCommitUrl] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  // 初期化: トークンがあれば接続状態を復元
+  useEffect(() => {
+    const init = async () => {
+      if (hasGitHubToken()) {
+        const savedToken = getGitHubToken()!;
+        const result = await validateGitHubToken(savedToken);
+        if (result.valid) {
+          setUsername(result.username || null);
+          setStep('connected');
+          const status = await getSyncStatus(savedToken);
+          setSyncStatus(status);
+        } else {
+          clearGitHubToken();
+        }
+      }
+    };
+    init();
+  }, []);
+
+  // トークン検証
+  const handleValidateToken = useCallback(async () => {
+    if (!token.trim()) return;
+
+    setIsValidating(true);
+    setError(null);
+
+    const result = await validateGitHubToken(token.trim());
+
+    if (result.valid) {
+      setGitHubToken(token.trim());
+      setUsername(result.username || null);
+      setStep('connected');
+      const status = await getSyncStatus(token.trim());
+      setSyncStatus(status);
+    } else {
+      setError(result.error || 'トークンの検証に失敗しました');
+    }
+
+    setIsValidating(false);
+  }, [token]);
+
+  // ログアウト
+  const handleDisconnect = useCallback(() => {
+    clearGitHubToken();
+    setUsername(null);
+    setToken('');
+    setSyncStatus(null);
+    setStep('setup');
+  }, []);
+
+  // プッシュ
+  const handlePush = useCallback(async () => {
+    const savedToken = getGitHubToken();
+    if (!savedToken) return;
+
+    setIsSyncing(true);
+    setError(null);
+    setSuccessMessage(null);
+
+    try {
+      const settings = await buildLearnedSettingsFromLocal();
+      const result = await pushLearnedSettings(savedToken, settings);
+
+      if (result.success) {
+        setLastCommitUrl(result.commitUrl || null);
+        setSuccessMessage('学習データをGitHubにプッシュしました');
+        const status = await getSyncStatus(savedToken);
+        setSyncStatus(status);
+      } else {
+        setError(result.error || 'プッシュに失敗しました');
+      }
+    } catch (e: any) {
+      setError(e.message || 'プッシュ中にエラーが発生しました');
+    }
+
+    setIsSyncing(false);
+  }, []);
+
+  // プル
+  const handlePull = useCallback(async () => {
+    const savedToken = getGitHubToken();
+    if (!savedToken) return;
+
+    setIsSyncing(true);
+    setError(null);
+    setSuccessMessage(null);
+
+    try {
+      const settings = await fetchLearnedSettings(savedToken);
+      if (settings) {
+        setSuccessMessage(`GitHubから設定を取得しました (v${settings.version})`);
+        const status = await getSyncStatus(savedToken);
+        setSyncStatus(status);
+      } else {
+        setError('設定の取得に失敗しました');
+      }
+    } catch (e: any) {
+      setError(e.message || 'プル中にエラーが発生しました');
+    }
+
+    setIsSyncing(false);
+  }, []);
+
+  // ステータス更新
+  const handleRefreshStatus = useCallback(async () => {
+    const savedToken = getGitHubToken();
+    if (!savedToken) return;
+
+    setIsSyncing(true);
+    const status = await getSyncStatus(savedToken);
+    setSyncStatus(status);
+    setIsSyncing(false);
+  }, []);
+
+  return {
+    step,
+    token,
+    username,
+    isValidating,
+    error,
+    syncStatus,
+    isSyncing,
+    lastCommitUrl,
+    successMessage,
+    setToken,
+    handleValidateToken,
+    handleDisconnect,
+    handlePush,
+    handlePull,
+    handleRefreshStatus,
+  };
+}

--- a/hooks/useModelValidationState.ts
+++ b/hooks/useModelValidationState.ts
@@ -1,0 +1,143 @@
+import { useState, useCallback } from 'react';
+import {
+  validateAllModels,
+  AVAILABLE_MODELS,
+  ModelType,
+  ModelStatus,
+  ModelAvailability,
+  getSelectedModel,
+  setSelectedModel,
+  getBestAvailableModel,
+  setTrustedSession
+} from '../services/geminiService';
+
+interface ModelValidationState {
+  selectedModel: ModelType;
+  isValidating: boolean;
+  modelAvailabilities: ModelAvailability[];
+  keyError: string | null;
+  trustSession: boolean;
+  hasAnyAvailable: boolean;
+}
+
+interface ModelValidationActions {
+  setTrustSession: (value: boolean) => void;
+  validateModels: (apiKey: string) => Promise<void>;
+  handleModelChange: (model: ModelType) => void;
+  handleSubmit: (apiKey: string, onComplete: (key: string) => void, registerBiometricCallback?: () => Promise<void>) => Promise<void>;
+  getStatusIcon: (status: ModelStatus) => 'available' | 'quota_exceeded' | 'unavailable' | 'checking' | 'error';
+  getStatusText: (status: ModelStatus, error?: string) => string;
+}
+
+export function useModelValidationState(): ModelValidationState & ModelValidationActions {
+  const [selectedModel, setSelectedModelState] = useState<ModelType>(getSelectedModel());
+  const [isValidating, setIsValidating] = useState(false);
+  const [modelAvailabilities, setModelAvailabilities] = useState<ModelAvailability[]>([]);
+  const [keyError, setKeyError] = useState<string | null>(null);
+  const [trustSession, setTrustSession] = useState(true);
+
+  const hasAnyAvailable = modelAvailabilities.some(m => m.status === 'available');
+
+  const validateModels = useCallback(async (apiKey: string) => {
+    setIsValidating(true);
+    setKeyError(null);
+    setModelAvailabilities(AVAILABLE_MODELS.map(m => ({ ...m, status: 'checking' as ModelStatus })));
+
+    const results = await validateAllModels(apiKey, (modelId, status, error) => {
+      setModelAvailabilities(prev =>
+        prev.map(m => m.id === modelId ? { ...m, status, error } : m)
+      );
+    });
+
+    setModelAvailabilities(results);
+    setIsValidating(false);
+
+    const allInvalid = results.every(r => r.error?.includes('無効'));
+    if (allInvalid) {
+      setKeyError('APIキーが無効です');
+    }
+
+    const bestModel = getBestAvailableModel(results);
+    if (bestModel) {
+      setSelectedModelState(bestModel);
+    }
+  }, []);
+
+  const handleModelChange = useCallback((model: ModelType) => {
+    const availability = modelAvailabilities.find(m => m.id === model);
+    if (availability?.status === 'available') {
+      setSelectedModelState(model);
+    }
+  }, [modelAvailabilities]);
+
+  const handleSubmit = useCallback(async (
+    apiKey: string,
+    onComplete: (key: string) => void,
+    registerBiometricCallback?: () => Promise<void>
+  ) => {
+    const selectedAvailability = modelAvailabilities.find(m => m.id === selectedModel);
+
+    if (!selectedAvailability || selectedAvailability.status !== 'available') {
+      const bestModel = getBestAvailableModel(modelAvailabilities);
+      if (bestModel) {
+        setSelectedModel(bestModel);
+      } else {
+        return;
+      }
+    } else {
+      setSelectedModel(selectedModel);
+    }
+
+    if (registerBiometricCallback) {
+      await registerBiometricCallback();
+    }
+
+    setTrustedSession(trustSession);
+    onComplete(apiKey);
+  }, [modelAvailabilities, selectedModel, trustSession]);
+
+  const getStatusIcon = useCallback((status: ModelStatus): 'available' | 'quota_exceeded' | 'unavailable' | 'checking' | 'error' => {
+    switch (status) {
+      case 'available':
+        return 'available';
+      case 'quota_exceeded':
+        return 'quota_exceeded';
+      case 'unavailable':
+        return 'unavailable';
+      case 'checking':
+        return 'checking';
+      default:
+        return 'error';
+    }
+  }, []);
+
+  const getStatusText = useCallback((status: ModelStatus, error?: string): string => {
+    switch (status) {
+      case 'available':
+        return '利用可能';
+      case 'quota_exceeded':
+        return '制限超過';
+      case 'unavailable':
+        return error || '利用不可';
+      case 'checking':
+        return '確認中...';
+      default:
+        return error || 'エラー';
+    }
+  }, []);
+
+  return {
+    selectedModel,
+    isValidating,
+    modelAvailabilities,
+    keyError,
+    trustSession,
+    hasAnyAvailable,
+    setTrustSession,
+    validateModels,
+    handleModelChange,
+    handleSubmit,
+    getStatusIcon,
+    getStatusText,
+  };
+}

--- a/hooks/usePreviewViewState.ts
+++ b/hooks/usePreviewViewState.ts
@@ -1,0 +1,122 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { PhotoRecord } from '../types';
+import { generateZip } from '../utils/zipGenerator';
+
+const A4_WIDTH_PX = 794;
+
+declare const saveAs: any;
+
+interface PreviewLayoutState {
+  scale: number;
+  isFitMode: boolean;
+  photosPerPage: 2 | 3;
+}
+
+interface ExportState {
+  isGeneratingPdf: boolean;
+  isGeneratingZip: boolean;
+}
+
+interface PanelState {
+  showConsole: boolean;
+  showHistoryPanel: boolean;
+}
+
+interface PreviewViewState extends PreviewLayoutState, ExportState, PanelState {
+  previewContainerRef: React.RefObject<HTMLDivElement>;
+}
+
+interface PreviewViewActions {
+  setPhotosPerPage: (value: 2 | 3) => void;
+  setShowConsole: (value: boolean) => void;
+  setShowHistoryPanel: (value: boolean) => void;
+  handleDownloadPDF: (photos: PhotoRecord[], txt: { pdfError: string }) => Promise<void>;
+  handleDownloadZip: (photos: PhotoRecord[]) => Promise<void>;
+  handleAutoPairClick: (onAutoPair: () => void) => void;
+  handleManualPairClick: (onManualPair: () => void) => void;
+}
+
+export function usePreviewViewState(initialLayout: 2 | 3): PreviewViewState & PreviewViewActions {
+  const [scale, setScale] = useState(1);
+  const [isFitMode, setIsFitMode] = useState(true);
+  const [photosPerPage, setPhotosPerPage] = useState<2 | 3>(initialLayout);
+  const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
+  const [isGeneratingZip, setIsGeneratingZip] = useState(false);
+  const [showConsole, setShowConsole] = useState(true);
+  const [showHistoryPanel, setShowHistoryPanel] = useState(false);
+  const previewContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setPhotosPerPage(initialLayout);
+  }, [initialLayout]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (!previewContainerRef.current) return;
+      const containerWidth = previewContainerRef.current.clientWidth;
+      const availableWidth = containerWidth - 32;
+      setScale(isFitMode && availableWidth < A4_WIDTH_PX ? availableWidth / A4_WIDTH_PX : 1);
+    };
+    window.addEventListener('resize', handleResize);
+    handleResize();
+    return () => window.removeEventListener('resize', handleResize);
+  }, [isFitMode]);
+
+  const handleDownloadPDF = useCallback(async (photos: PhotoRecord[], txt: { pdfError: string }) => {
+    setIsGeneratingPdf(true);
+    try {
+      const { generatePdfWithImages } = await import('../utils/pdfGenerator');
+      const pdfBlob = await generatePdfWithImages(photos, photosPerPage, '工事写真帳');
+      const filename = `construction_album_${new Date().toISOString().slice(0, 10)}.pdf`;
+      saveAs(pdfBlob, filename);
+      window.open(URL.createObjectURL(pdfBlob), '_blank');
+    } catch (err) {
+      console.error('PDF generation error:', err);
+      alert(txt.pdfError);
+    } finally {
+      setIsGeneratingPdf(false);
+    }
+  }, [photosPerPage]);
+
+  const handleDownloadZip = useCallback(async (photos: PhotoRecord[]) => {
+    if (photos.length === 0) return;
+    setIsGeneratingZip(true);
+    try {
+      const blob = await generateZip(photos);
+      saveAs(blob, `electronic_delivery_${new Date().toISOString().slice(0, 10)}.zip`);
+    } catch (e) {
+      console.error(e);
+      alert("Failed to generate ZIP.");
+    } finally {
+      setIsGeneratingZip(false);
+    }
+  }, []);
+
+  const handleAutoPairClick = useCallback((onAutoPair: () => void) => {
+    if (photosPerPage !== 2) setPhotosPerPage(2);
+    onAutoPair();
+  }, [photosPerPage]);
+
+  const handleManualPairClick = useCallback((onManualPair: () => void) => {
+    setPhotosPerPage(2);
+    onManualPair();
+  }, []);
+
+  return {
+    scale,
+    isFitMode,
+    photosPerPage,
+    isGeneratingPdf,
+    isGeneratingZip,
+    showConsole,
+    showHistoryPanel,
+    previewContainerRef,
+    setPhotosPerPage,
+    setShowConsole,
+    setShowHistoryPanel,
+    handleDownloadPDF,
+    handleDownloadZip,
+    handleAutoPairClick,
+    handleManualPairClick,
+  };
+}


### PR DESCRIPTION
複雑なuseState管理をカスタムフックに分離して保守性を向上:

- useApiKeySetupState: ApiKeySetup.tsxの状態管理 (6 useState → 1 hook)
- useDashboardState: CodebaseHealthDashboard.tsxの状態管理 (6 useState → 1 hook)
- useGitHubSyncState: GitHubSyncPanel.tsxの状態管理 (9 useState → 1 hook)
- useModelValidationState + useBiometricAuth: ModelValidation.tsxを分割 (10 useState → 2 hooks)
- usePreviewViewState: PreviewView.tsxの状態管理 (7 useState → 1 hook)

各コンポーネント内のuseState数を3個以下に削減