### PR TITLE
Sync history settings to AI framework

### DIFF
--- a/services/gemini/analysis.ts
+++ b/services/gemini/analysis.ts
@@ -17,7 +17,7 @@ import { PhotoRecord, AIAnalysisResult, AppMode } from "../../types";
 import { extractBase64Data } from "../../utils/imageUtils";
 import { formatHierarchyForPrompt } from "../../utils/constructionMaster";
 import { trackUsage } from "../usageTracker";
-import { getRelevantExamples, getActiveSession } from "../../utils/storage";
+import { getRelevantExamples, getActiveSession, getActiveExampleHistoryId, getAnalysisHistoryEntry } from "../../utils/storage";
 import { RuleSettings } from "../../utils/analysisRules";
 import { getLearnedSettings, rulesToPromptText as learnedRulesToPromptText } from "../learningService";
 // Core module - サブモジュールを統合
@@ -221,10 +221,21 @@ async function prepareAnalysisInputs(
   let examplesPrompt = "";
   if (appMode === 'construction') {
     try {
+      // セッションベースのお手本をチェック
       const activeSession = await getActiveSession();
       if (activeSession) {
         onLog?.(`[EXAMPLES] お手本セッション適用中: "${activeSession.name}" (${activeSession.photoCount}枚)`, "info");
       }
+
+      // 履歴ベースのお手本をチェック（新機能）
+      const activeHistoryId = getActiveExampleHistoryId();
+      if (activeHistoryId && !activeSession) {
+        const historyEntry = await getAnalysisHistoryEntry(activeHistoryId);
+        if (historyEntry && historyEntry.isExampleSession) {
+          onLog?.(`[EXAMPLES] 履歴お手本適用中: "${historyEntry.name}" (${historyEntry.photoCount}枚)`, "info");
+        }
+      }
+
       const examples = await getRelevantExamples(undefined, undefined, 5);
       if (examples.length > 0) {
         examplesPrompt = formatExamplesForPrompt(examples);

--- a/utils/storage/analysisCache.ts
+++ b/utils/storage/analysisCache.ts
@@ -100,3 +100,23 @@ export const clearAnalysisCache = async (): Promise<void> => {
     request.onerror = () => reject(request.error);
   });
 };
+
+/**
+ * Get cached analysis by key directly
+ */
+export const getCachedAnalysisByKey = async (key: string): Promise<AIAnalysisResult | null> => {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_CACHE, 'readonly');
+    const store = transaction.objectStore(STORE_CACHE);
+    const request = store.get(key);
+
+    request.onsuccess = () => {
+      resolve(request.result as AIAnalysisResult || null);
+    };
+    request.onerror = () => {
+      console.warn("Cache lookup by key failed", request.error);
+      resolve(null);
+    };
+  });
+};

--- a/utils/storage/examples.ts
+++ b/utils/storage/examples.ts
@@ -4,6 +4,8 @@ import { PhotoRecord, AnalysisExample, PhotoCategory } from "../../types";
 import { openDB, STORE_EXAMPLES } from "./dbCore";
 import { detectPhotoCategory } from "./categoryUtils";
 import { getSession, getActiveSessionId } from "./sessions";
+import { getActiveExampleHistoryId, getAnalysisHistoryEntry } from "./history";
+import { getCachedAnalysisByKey } from "./analysisCache";
 
 /**
  * Save example from PhotoRecord
@@ -115,12 +117,14 @@ export const clearExamples = async (): Promise<void> => {
 
 /**
  * Get relevant examples for analysis
+ * Checks both session examples and history-based examples
  */
 export const getRelevantExamples = async (
   workType?: string,
   category?: PhotoCategory,
   limit: number = 3
 ): Promise<AnalysisExample[]> => {
+  // 1. まずセッションベースのお手本をチェック
   const activeSessionId = getActiveSessionId();
   if (activeSessionId) {
     const session = await getSession(activeSessionId);
@@ -139,6 +143,48 @@ export const getRelevantExamples = async (
     }
   }
 
+  // 2. 履歴ベースのお手本をチェック（新機能）
+  const activeHistoryId = getActiveExampleHistoryId();
+  if (activeHistoryId) {
+    const historyEntry = await getAnalysisHistoryEntry(activeHistoryId);
+    if (historyEntry && historyEntry.isExampleSession && historyEntry.photoKeys.length > 0) {
+      // 履歴のphotoKeysからキャッシュを取得してお手本に変換
+      const examplesFromHistory: AnalysisExample[] = [];
+      for (let i = 0; i < Math.min(historyEntry.photoKeys.length, limit * 2); i++) {
+        const key = historyEntry.photoKeys[i];
+        const analysis = await getCachedAnalysisByKey(key);
+        if (analysis) {
+          examplesFromHistory.push({
+            id: `hist_${historyEntry.id}_${i}`,
+            name: `${analysis.workType || ''} - ${analysis.remarks || key}`,
+            thumbnail: historyEntry.thumbnails?.[i] || '',
+            analysis,
+            category: detectPhotoCategory(analysis),
+            tags: [],
+            createdAt: historyEntry.createdAt,
+            updatedAt: historyEntry.createdAt
+          });
+        }
+      }
+
+      if (examplesFromHistory.length > 0) {
+        console.log(`[EXAMPLES] 履歴お手本から${examplesFromHistory.length}件取得: "${historyEntry.name}"`);
+        const scored = examplesFromHistory.map(ex => {
+          let score = 0;
+          if (category && ex.category === category) score += 3;
+          if (workType && ex.analysis.workType === workType) score += 2;
+          score += 1;
+          return { example: ex, score };
+        });
+        return scored
+          .sort((a, b) => b.score - a.score)
+          .slice(0, limit)
+          .map(s => s.example);
+      }
+    }
+  }
+
+  // 3. フォールバック: すべてのお手本から取得
   const all = await getExamples();
   if (all.length === 0) return [];
 

--- a/utils/storage/index.ts
+++ b/utils/storage/index.ts
@@ -7,7 +7,7 @@ export { openDB } from './dbCore';
 export { saveProjectData, loadProjectData, clearProjectData } from './projectData';
 
 // Analysis Cache
-export { getFileKey, generateSessionKey, getCachedAnalysis, cacheAnalysis, clearAnalysisCache } from './analysisCache';
+export { getFileKey, generateSessionKey, getCachedAnalysis, getCachedAnalysisByKey, cacheAnalysis, clearAnalysisCache } from './analysisCache';
 
 // Rules
 export { saveRule, getRules, deleteRule } from './rules';


### PR DESCRIPTION
問題: 履歴パネルでお手本設定(activeExampleHistoryId)しても、
AI解析時はセッションベース(activeExampleSession)しか参照していなかった

修正内容:
- getRelevantExamples()で履歴ベースのお手本も参照するよう拡張
- 履歴のphotoKeysからキャッシュ経由で解析結果を取得
- analysis.tsで履歴お手本のログを出力
- getCachedAnalysisByKey()を追加してキーから直接キャッシュ取得可能に