### PR TITLE
Reduce JSX nesting depth in editor components

### DIFF
--- a/components/BulkEntryEditor.tsx
+++ b/components/BulkEntryEditor.tsx
@@ -265,7 +265,7 @@ const HistoryDropdown: React.FC<{
     </div>
     {history.map((s, i) => (
       <button
-        key={i}
+        key={`${s}-${i}`}
         type="button"
         onClick={() => onSelect(s)}
         className="w-full text-left px-3 py-2 hover:bg-blue-50 font-mono text-sm border-b last:border-b-0"


### PR DESCRIPTION
- BulkEntryEditor.tsx: 深度19→10程度
  - BulkEditorHeader, FieldSelector, InputModeTabs等を抽出
  - PhotoGroup, PhotoGroupHeaderを分離
  - FreeInputField, HistoryDropdown等を独立コンポーネント化

- EditableTreeView.tsx: 深度19→10程度
  - TreeItemコンポーネントを抽出してネストを削減
  - renderItemContent関数でロジックを整理

- AliasSettingsView.tsx: 深度12→8程度
  - AliasHeader, EnableToggle, PresetSelectorを抽出
  - AliasSection, PreviewSection, ApplyToSessionSectionを分離