### PR TITLE
Handle invalid AI framework local settings

### DIFF
--- a/hooks/useAIFrameworkState.ts
+++ b/hooks/useAIFrameworkState.ts
@@ -22,6 +22,34 @@ const STORAGE_KEYS = {
   temperature: 'ai_temperature',
 };
 
+const DEFAULT_FLOW_SETTINGS = { detect: true, worktype: true, normalize: true, scene: true };
+
+const loadFlowSettingsSafely = (): Record<string, boolean> => {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEYS.flowSettings);
+    if (!saved) return { ...DEFAULT_FLOW_SETTINGS };
+
+    const parsed = JSON.parse(saved);
+    if (parsed && typeof parsed === 'object') {
+      return { ...DEFAULT_FLOW_SETTINGS, ...parsed };
+    }
+  } catch (e) {
+    console.warn('Failed to load flow settings, resetting to defaults:', e);
+  }
+
+  localStorage.removeItem(STORAGE_KEYS.flowSettings);
+  return { ...DEFAULT_FLOW_SETTINGS };
+};
+
+const loadTemperatureSafely = (): number => {
+  const raw = localStorage.getItem(STORAGE_KEYS.temperature);
+  const parsed = raw !== null ? parseFloat(raw) : 0.1;
+  if (Number.isFinite(parsed)) return parsed;
+
+  localStorage.removeItem(STORAGE_KEYS.temperature);
+  return 0.1;
+};
+
 export function useAIFrameworkState(appMode: AppMode) {
   // UI State
   const [activeTab, setActiveTab] = useState<TabType>('prompt');
@@ -34,13 +62,10 @@ export function useAIFrameworkState(appMode: AppMode) {
   const [ruleSettings, setRuleSettings] = useState<RuleSettings>(loadRuleSettings());
   const [customInstruction, setCustomInstruction] = useState(() => localStorage.getItem(STORAGE_KEYS.customInstruction) || '');
   const [selectedModel, setSelectedModelState] = useState<ModelType>(getSelectedModel());
-  const [temperature, setTemperature] = useState(() => parseFloat(localStorage.getItem(STORAGE_KEYS.temperature) || '0.1'));
+  const [temperature, setTemperature] = useState(loadTemperatureSafely);
   const [systemOverride, setSystemOverride] = useState(() => localStorage.getItem(STORAGE_KEYS.systemOverride) || '');
   const [hierarchyOverride, setHierarchyOverride] = useState(() => localStorage.getItem(STORAGE_KEYS.hierarchyOverride) || '');
-  const [flowSettings, setFlowSettings] = useState<Record<string, boolean>>(() => {
-    const saved = localStorage.getItem(STORAGE_KEYS.flowSettings);
-    return saved ? JSON.parse(saved) : { detect: true, worktype: true, normalize: true, scene: true };
-  });
+  const [flowSettings, setFlowSettings] = useState<Record<string, boolean>>(loadFlowSettingsSafely);
 
   // Async Loaded Data
   const [learnedSettings, setLearnedSettings] = useState<LearnedSettings | null>(null);

--- a/tests/useAIFrameworkState.test.ts
+++ b/tests/useAIFrameworkState.test.ts
@@ -217,6 +217,15 @@ describe('useAIFrameworkState', () => {
 
       expect(result.current.temperature).toBe(0.7);
     });
+
+    it('should reset invalid stored temperature', () => {
+      localStorage.setItem('ai_temperature', 'NaN');
+
+      const { result } = renderHook(() => useAIFrameworkState(appMode));
+
+      expect(result.current.temperature).toBe(0.1);
+      expect(localStorage.getItem('ai_temperature')).toBeNull();
+    });
   });
 
   describe('Flow Settings', () => {
@@ -239,6 +248,20 @@ describe('useAIFrameworkState', () => {
 
       const saved = JSON.parse(localStorage.getItem('ai_flow_settings') || '{}');
       expect(saved.normalize).toBe(false);
+    });
+
+    it('should recover from invalid stored JSON', () => {
+      localStorage.setItem('ai_flow_settings', 'not-json');
+
+      const { result } = renderHook(() => useAIFrameworkState(appMode));
+
+      expect(result.current.flowSettings).toEqual({
+        detect: true,
+        worktype: true,
+        normalize: true,
+        scene: true,
+      });
+      expect(localStorage.getItem('ai_flow_settings')).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- guard AI Framework Dashboard state against corrupted localStorage values for flow settings and temperature to avoid crashes when opening the view
- reset invalid cached values back to defaults and clear the broken entries
- add regression tests covering recovery paths for flow settings and temperature storage

## Testing
- `npm test` *(fails: tests/geminiService.security.test.ts expecting no API key in localStorage; tests/layoutConfig.test.ts expecting legacy row/rows values)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69536f4a94ec832083000eeedab704c5)