### PR TITLE
Fix unnecessary password lock on API key startup

### DIFF
--- a/components/ApiKeySetup.tsx
+++ b/components/ApiKeySetup.tsx
@@ -1,43 +1,22 @@
 import React from 'react';
-import { ExternalLink, Key, Camera, ArrowLeft, Lock, Shield, Loader2 } from 'lucide-react';
+import { ExternalLink, Key, Camera, ArrowLeft } from 'lucide-react';
 import { useApiKeySetupState } from '../hooks/useApiKeySetupState';
 
 interface ApiKeySetupProps {
   onComplete: (apiKey: string) => void;
-  onUnlock?: (apiKey: string) => void;  // ロック解除時のコールバック（モデル検証スキップ用）
+  onUnlock?: (apiKey: string) => void;  // 後方互換性のため残す
   onCancel?: () => void;
   onImportPdf?: () => void;
 }
 
-const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onComplete, onUnlock, onCancel, onImportPdf }) => {
+const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onComplete, onCancel, onImportPdf }) => {
   const {
-    mode,
     apiKey,
-    masterPassword,
-    confirmPassword,
     error,
-    loading,
     isValidKey,
-    isValidPassword,
-    passwordsMatch,
     setApiKey,
-    setMasterPassword,
-    setConfirmPassword,
-    handleUnlock,
     handleSubmit,
-    handleResetKey,
   } = useApiKeySetupState();
-
-  // ロック解除時のコールバック（onUnlockがあればそちらを使う）
-  const handleUnlockComplete = onUnlock || onComplete;
-
-  if (mode === 'check') {
-    return (
-      <div className="fixed inset-0 bg-slate-900 z-[130] flex items-center justify-center">
-        <Loader2 className="w-8 h-8 text-blue-500 animate-spin" />
-      </div>
-    );
-  }
 
   return (
     <div className="fixed inset-0 bg-slate-900 z-[130] flex flex-col">
@@ -64,60 +43,12 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onComplete, onUnlock, onCance
             </div>
             <h2 className="text-xl font-black text-white mb-2">工事写真帳メーカー</h2>
             <p className="text-sm text-slate-400">
-              {mode === 'unlock' ? 'パスワードでアンロック' : 'AIで工事写真を自動分類・整理します'}
+              AIで工事写真を自動分類・整理します
             </p>
           </div>
 
-          {/* アンロックモード */}
-          {mode === 'unlock' && (
-            <div className="space-y-4">
-              <div className="bg-slate-800/50 rounded-2xl p-6 border border-slate-700">
-                <div className="flex items-center justify-center mb-4">
-                  <div className="w-16 h-16 bg-green-500/20 rounded-full flex items-center justify-center">
-                    <Shield size={32} className="text-green-500" />
-                  </div>
-                </div>
-                <p className="text-center text-sm text-slate-300 mb-4">
-                  暗号化されたAPIキーが保存されています
-                </p>
-                <div className="space-y-3">
-                  <div className="flex items-center gap-2">
-                    <Lock size={18} className="text-slate-500 shrink-0" />
-                    <input
-                      type="password"
-                      value={masterPassword}
-                      onChange={(e) => setMasterPassword(e.target.value)}
-                      onKeyDown={(e) => e.key === 'Enter' && handleUnlock(handleUnlockComplete)}
-                      placeholder="マスターパスワード"
-                      className="flex-1 bg-slate-900 border border-slate-600 rounded-lg px-3 py-3 text-white placeholder-slate-500 focus:outline-none focus:border-blue-500 text-sm"
-                      autoFocus
-                    />
-                  </div>
-                  {error && (
-                    <p className="text-red-400 text-xs text-center">{error}</p>
-                  )}
-                  <button
-                    onClick={() => handleUnlock(handleUnlockComplete)}
-                    disabled={loading || !masterPassword}
-                    className="w-full bg-blue-500 hover:bg-blue-400 disabled:bg-slate-700 disabled:text-slate-500 text-white font-bold py-3 rounded-xl transition-all flex items-center justify-center gap-2"
-                  >
-                    {loading ? <Loader2 size={18} className="animate-spin" /> : null}
-                    アンロック
-                  </button>
-                </div>
-              </div>
-              <button
-                onClick={handleResetKey}
-                className="w-full text-slate-500 hover:text-slate-300 text-xs py-2 transition-colors"
-              >
-                キーを再設定する
-              </button>
-            </div>
-          )}
-
-          {/* 新規設定モード */}
-          {mode === 'new' && (
-            <>
+          {/* APIキー設定 */}
+          <>
               {/* PDF読み込みオプション */}
               {onImportPdf && (
                 <>
@@ -186,67 +117,31 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onComplete, onUnlock, onCance
                 </div>
               </div>
 
-              {/* ステップ3: マスターパスワード */}
-              <div className="bg-slate-800/50 rounded-2xl p-4 border border-slate-700">
-                <div className="flex items-center gap-2 mb-2">
-                  <span className="w-6 h-6 bg-green-500 text-white text-xs font-bold rounded-full flex items-center justify-center">3</span>
-                  <span className="text-sm font-bold text-white">マスターパスワードを設定</span>
-                </div>
-                <p className="text-[10px] text-slate-500 mb-2">
-                  APIキーを暗号化して安全に保存します
-                </p>
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <Lock size={18} className="text-slate-500 shrink-0" />
-                    <input
-                      type="password"
-                      value={masterPassword}
-                      onChange={(e) => setMasterPassword(e.target.value)}
-                      placeholder="パスワード（4文字以上）"
-                      className="flex-1 bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-500 focus:outline-none focus:border-blue-500 text-sm"
-                    />
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Lock size={18} className="text-slate-500 shrink-0" />
-                    <input
-                      type="password"
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
-                      placeholder="パスワード（確認）"
-                      className="flex-1 bg-slate-900 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-500 focus:outline-none focus:border-blue-500 text-sm"
-                    />
-                  </div>
-                </div>
-              </div>
-
               {error && (
                 <p className="text-red-400 text-xs text-center">{error}</p>
               )}
 
               {/* 注意事項 */}
               <p className="text-[10px] text-slate-500 text-center">
-                キーは暗号化されてこのブラウザに保存されます
+                キーはこのブラウザに保存されます
               </p>
             </>
-          )}
+
         </div>
       </div>
 
       {/* フッター */}
-      {mode === 'new' && (
-        <div className="p-4 border-t border-slate-800 bg-slate-900">
-          <div className="max-w-md mx-auto">
-            <button
-              onClick={() => handleSubmit(onComplete)}
-              disabled={!isValidKey || !isValidPassword || !passwordsMatch || loading}
-              className="w-full bg-blue-500 hover:bg-blue-400 disabled:bg-slate-700 disabled:text-slate-500 text-white font-bold py-3 rounded-xl transition-all flex items-center justify-center gap-2"
-            >
-              {loading ? <Loader2 size={18} className="animate-spin" /> : null}
-              暗号化して保存
-            </button>
-          </div>
+      <div className="p-4 border-t border-slate-800 bg-slate-900">
+        <div className="max-w-md mx-auto">
+          <button
+            onClick={() => handleSubmit(onComplete)}
+            disabled={!isValidKey}
+            className="w-full bg-blue-500 hover:bg-blue-400 disabled:bg-slate-700 disabled:text-slate-500 text-white font-bold py-3 rounded-xl transition-all flex items-center justify-center gap-2"
+          >
+            保存
+          </button>
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/hooks/useApiKey.ts
+++ b/hooks/useApiKey.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { getApiKey, setApiKey as saveApiKey, hasEncryptedApiKey } from '../services/geminiService';
+import { getApiKey, setApiKey as saveApiKey } from '../services/geminiService';
 
 /**
  * APIキー管理のカスタムフック
@@ -8,13 +8,8 @@ export function useApiKey() {
   // 初期化を同期的に行う（useEffectだと一瞬「キー未設定」が表示される）
   const [apiKey, setApiKeyState] = useState<string | null>(() => getApiKey());
   const [pendingApiKey, setPendingApiKey] = useState<string | null>(null);
-  // 暗号化されたキーが存在するかどうか（ロック状態）
-  // 初回レンダリング時点で同期的に判定
-  const [isLocked, setIsLocked] = useState<boolean>(() => {
-    const storedKey = getApiKey();
-    // キーがメモリ/セッションにないが、暗号化されたキーがある = ロック状態
-    return !storedKey && hasEncryptedApiKey();
-  });
+  // 起動時ロックは廃止（パスワードはAPIキー変更時のみ使用）
+  const [isLocked, setIsLocked] = useState<boolean>(false);
 
   // ApiKeySetup → ModelValidation への遷移用
   const handleApiKeyInput = useCallback((key: string) => {

--- a/hooks/useApiKeySetupState.ts
+++ b/hooks/useApiKeySetupState.ts
@@ -1,14 +1,13 @@
-import { useState, useEffect, useCallback } from 'react';
-import { hasEncryptedApiKey, loadApiKeyEncrypted, setApiKeyEncrypted } from '../services/geminiService';
-import { hashPassword } from '../utils/crypto';
+import { useState, useCallback } from 'react';
+import { setApiKey as saveApiKey } from '../services/geminiService';
 
-type SetupMode = 'check' | 'unlock' | 'new';
+type SetupMode = 'new';  // 常に新規設定モード（パスワードロックは廃止）
 
 interface ApiKeySetupState {
   mode: SetupMode;
   apiKey: string;
-  masterPassword: string;
-  confirmPassword: string;
+  masterPassword: string;      // 後方互換性のため残す（使用しない）
+  confirmPassword: string;     // 後方互換性のため残す（使用しない）
   error: string;
   loading: boolean;
 }
@@ -18,104 +17,54 @@ interface ApiKeySetupActions {
   setMasterPassword: (value: string) => void;
   setConfirmPassword: (value: string) => void;
   handleUnlock: (onComplete: (key: string) => void) => Promise<void>;
-  handleSubmit: (onComplete: (key: string) => void) => Promise<void>;
+  handleSubmit: (onComplete: (key: string) => void) => void;
   handleResetKey: () => void;
 }
 
 interface ApiKeySetupValidation {
   isValidKey: boolean;
-  isValidPassword: boolean;
-  passwordsMatch: boolean;
+  isValidPassword: boolean;    // 常にtrue（パスワード不要）
+  passwordsMatch: boolean;     // 常にtrue（パスワード不要）
 }
 
 export function useApiKeySetupState(): ApiKeySetupState & ApiKeySetupActions & ApiKeySetupValidation {
-  const [mode, setMode] = useState<SetupMode>('check');
+  const [mode] = useState<SetupMode>('new');  // 常に新規設定モード
   const [apiKey, setApiKey] = useState('');
   const [masterPassword, setMasterPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
+  const [loading] = useState(false);
 
   const isValidKey = apiKey.trim().startsWith('AIza') && apiKey.trim().length >= 39;
-  const isValidPassword = masterPassword.length >= 4;
-  const passwordsMatch = masterPassword === confirmPassword;
+  const isValidPassword = true;   // パスワード不要
+  const passwordsMatch = true;    // パスワード不要
 
-  // 初期化: 暗号化されたキーがあるかチェック
-  useEffect(() => {
-    if (hasEncryptedApiKey()) {
-      setMode('unlock');
-    } else {
-      setMode('new');
-    }
+  // アンロック処理（後方互換性のため残す - 実際には使用されない）
+  const handleUnlock = useCallback(async (_onComplete: (key: string) => void) => {
+    // パスワードロックは廃止されたため何もしない
   }, []);
 
-  // アンロック処理
-  const handleUnlock = useCallback(async (onComplete: (key: string) => void) => {
-    if (!masterPassword) {
-      setError('パスワードを入力してください');
-      return;
-    }
-
-    setLoading(true);
-    setError('');
-
-    try {
-      const success = await loadApiKeyEncrypted(masterPassword);
-      if (success) {
-        const { getApiKey } = await import('../services/geminiService');
-        const key = getApiKey();
-        if (key) {
-          onComplete(key);
-        } else {
-          setError('キーの読み込みに失敗しました');
-        }
-      } else {
-        setError('パスワードが違います');
-      }
-    } catch {
-      setError('復号に失敗しました');
-    } finally {
-      setLoading(false);
-    }
-  }, [masterPassword]);
-
-  // 新規設定処理
-  const handleSubmit = useCallback(async (onComplete: (key: string) => void) => {
+  // 新規設定処理（パスワードなしでlocalStorageに保存）
+  const handleSubmit = useCallback((onComplete: (key: string) => void) => {
     if (!isValidKey) {
       setError('有効なAPIキーを入力してください');
       return;
     }
-    if (!isValidPassword) {
-      setError('パスワードは4文字以上で入力してください');
-      return;
-    }
-    if (!passwordsMatch) {
-      setError('パスワードが一致しません');
-      return;
-    }
 
-    setLoading(true);
-    setError('');
+    const trimmedKey = apiKey.trim();
+    saveApiKey(trimmedKey);
+    // 旧暗号化データがあれば削除
+    localStorage.removeItem('gaspm_encrypted_api_key');
+    localStorage.removeItem('gaspm_master_hash');
+    onComplete(trimmedKey);
+  }, [apiKey, isValidKey]);
 
-    try {
-      const hash = await hashPassword(masterPassword);
-      localStorage.setItem('gaspm_master_hash', hash);
-      await setApiKeyEncrypted(apiKey.trim(), masterPassword);
-      onComplete(apiKey.trim());
-    } catch (e: any) {
-      setError('保存に失敗しました: ' + e.message);
-    } finally {
-      setLoading(false);
-    }
-  }, [apiKey, masterPassword, isValidKey, isValidPassword, passwordsMatch]);
-
-  // 新規設定に切り替え（暗号化キーを破棄）
+  // キーリセット（後方互換性のため残す）
   const handleResetKey = useCallback(() => {
-    if (window.confirm('保存されたAPIキーを削除しますか？新しいキーを設定できます。')) {
+    if (window.confirm('保存されたAPIキーを削除しますか？')) {
+      localStorage.removeItem('construction_album_api_key');
       localStorage.removeItem('gaspm_encrypted_api_key');
       localStorage.removeItem('gaspm_master_hash');
-      setMode('new');
-      setMasterPassword('');
       setError('');
     }
   }, []);

--- a/services/gemini/apiKey.ts
+++ b/services/gemini/apiKey.ts
@@ -46,7 +46,8 @@ export const getApiKey = (): string | null => {
 export const setApiKey = (key: string): void => {
   cachedApiKey = key;
   sessionStorage.setItem(API_KEY_STORAGE_KEY, key);
-  // NOTE: 平文のAPIキーは永続ストレージには保存しない
+  // localStorageにも保存（起動時に自動復元するため）
+  localStorage.setItem(API_KEY_STORAGE_KEY, key);
 };
 
 // 暗号化してAPIキーを保存


### PR DESCRIPTION
- APIキーをlocalStorageに平文保存し、起動時に自動復元するように変更
- 毎回パスワード入力を求めていた非合理的な動作を修正
- パスワード関連UIを簡素化（設定変更時のロック機能は後で再実装予定）