### PR TITLE
security: harden vite config — remove key define + disable prod sourcemap (P0 of #179)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -30,7 +30,6 @@ function analyzePlugin() {
 }
 
 export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
     return {
       base: '/GASPhotoAIManager/',
       // YAMLファイルをアセットとして認識（import.meta.globのフォールバック用）
@@ -45,17 +44,13 @@ export default defineConfig(({ mode }) => {
         },
       },
       plugins: [react(), analyzePlugin()],
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-      },
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
       },
       build: {
-        sourcemap: true,
+        sourcemap: mode !== 'production',
         rollupOptions: {
           output: {
             manualChunks: (id) => {


### PR DESCRIPTION
## Summary

Addresses the two P0 items from #179 (Qiita『900万円請求』監査).

- **P0-1**: Remove the `define` block in `vite.config.ts` that string-substituted `env.GEMINI_API_KEY` into `process.env.API_KEY` / `process.env.GEMINI_API_KEY`. Under BYOK (`ApiKeySetup.tsx` + localStorage) this embed is unused at runtime but a live landmine the moment any CI secret is added. Also drops the now-unused `loadEnv` import and `const env = loadEnv(...)` line. Node-side consumers in `scripts/*` and `cli/*` continue to read `process.env.GEMINI_API_KEY` directly and are unaffected.
- **P0-2**: Switch `build.sourcemap` to `mode !== 'production'` so prod no longer ships `*.js.map` files that expose source (and would double-expose any embedded secret if P0-1 regressed).

## Verification

- `npm run build` → succeeds (exit 0, no TS/Rollup errors).
- `grep -rE 'AIza[A-Za-z0-9_-]{35}' dist/` → no matches.
- `find dist -name '*.map'` → no matches.

## Issue #179 checklist status

- [x] P0-1: `vite.config.ts` の `define` から GEMINI_API_KEY 関連を削除
- [x] P0-2: `build.sourcemap` を本番で無効化 (`mode !== 'production'` 分岐)
- [ ] P1: CDN 5本を npm バンドル化 (or SRI 付与) — 未着手
- [ ] P2: `ApiKeySetup.tsx` にリファラー制限の案内追加 — 未着手
- [ ] P3: `SECURITY.md` を実体のある内容へ — 未着手
- [ ] P4: gitleaks / Secret scanning 有効化 — 未着手
- [ ] P5: `index.html` に CSP meta 追加 — 未着手

refs #179 (P0 only; P1-P5 tracked separately)

## Test plan

- [ ] CI build passes on this branch
- [ ] `dist/` contains no `*.map` files
- [ ] `grep -rE 'AIza[A-Za-z0-9_-]{35}' dist/` returns nothing
- [ ] Dev mode still emits sourcemaps (`npm run dev`/`vite build --mode development`)
- [ ] BYOK flow (ApiKeySetup → localStorage) still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)