### PR TITLE
security: hardening — guidance + SECURITY + gitleaks + CSP (P2-P5 of #179)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,17 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify no secrets in build artifact
+        run: |
+          if grep -rE 'AIza[A-Za-z0-9_-]{35}' dist/; then
+            echo "::error::API key found in build output"
+            exit 1
+          fi
+          if find dist -name '*.map' | grep -q .; then
+            echo "::error::Sourcemap leaked to dist"
+            exit 1
+          fi
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
         with:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,12 @@
+name: Secret Scan
+on: [push, pull_request]
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,26 @@
 # Security Policy
 
-## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
-
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Please report security vulnerabilities privately via GitHub Security Advisories:
+https://github.com/YuujiKamura/GASPhotoAIManager/security/advisories/new
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Do NOT open a public issue for security problems.
+
+We aim to respond within 7 days.
+
+## Supported Versions
+
+Only the `main` branch is supported. This is a personal project with no versioned releases.
+
+## Threat Model
+
+This app is a browser-only BYOK (Bring Your Own Key) tool. Users provide their own Google AI Studio API key, stored in localStorage. The app has no backend that handles user keys.
+
+Primary risks we care about:
+- XSS / supply chain: any compromise that reads localStorage
+- Build-time key injection: keys embedded into client bundle at build time
+
+Out of scope:
+- DoS of the static site
+- Abuse of the user's own API key by themselves

--- a/components/ApiKeySetup.tsx
+++ b/components/ApiKeySetup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ExternalLink, Key, Camera, ArrowLeft, Shield, Trash2, CheckCircle } from 'lucide-react';
+import { ExternalLink, Key, Camera, ArrowLeft, Shield, Trash2, CheckCircle, AlertTriangle } from 'lucide-react';
 import { useApiKeySetupState } from '../hooks/useApiKeySetupState';
 
 interface ApiKeySetupProps {
@@ -122,6 +122,70 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onComplete, onCancel, onImpor
                   <div className="flex-1 h-px bg-slate-700"></div>
                 </div>
               )}
+
+              {/* セキュリティ警告: キー制限のお願い */}
+              <div className="bg-red-500/10 border border-red-500/40 rounded-2xl p-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <AlertTriangle size={18} className="text-red-400 shrink-0" />
+                  <span className="text-sm font-bold text-red-300">
+                    ⚠️ 安全のため、キーには必ず制限をかけてください
+                  </span>
+                </div>
+                <div className="text-xs text-slate-300 space-y-2">
+                  <p>
+                    キーが漏洩しても悪用されないよう、Google Cloud Console で以下の制限を設定してください：
+                  </p>
+                  <div className="bg-slate-900/60 rounded-lg p-3 space-y-2">
+                    <div>
+                      <div className="flex items-center gap-1 mb-1">
+                        <Shield size={12} className="text-amber-400" />
+                        <span className="text-[11px] font-bold text-amber-300">HTTP リファラー制限</span>
+                      </div>
+                      <code className="block text-[10px] text-slate-200 font-mono bg-slate-950/60 px-2 py-1 rounded break-all">
+                        https://yuujikamura.github.io/GASPhotoAIManager/*
+                      </code>
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-1 mb-1">
+                        <Shield size={12} className="text-amber-400" />
+                        <span className="text-[11px] font-bold text-amber-300">API 制限</span>
+                      </div>
+                      <p className="text-[11px] text-slate-300">
+                        「Generative Language API」のみ許可
+                      </p>
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-1 mb-1">
+                        <Shield size={12} className="text-amber-400" />
+                        <span className="text-[11px] font-bold text-amber-300">予算アラート（推奨）</span>
+                      </div>
+                      <p className="text-[11px] text-slate-300">
+                        月 $5 程度でアラートを設定しておくと安心です
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-1.5 pt-1">
+                    <a
+                      href="https://console.cloud.google.com/apis/credentials"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1 text-[11px] text-blue-400 hover:text-blue-300 transition-colors"
+                    >
+                      <ExternalLink size={10} />
+                      Google Cloud Console 認証情報ページを開く
+                    </a>
+                    <a
+                      href="https://qiita.com/pythonista0328/items/f9eb8b7fb6a14087df35"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1 text-[11px] text-blue-400 hover:text-blue-300 transition-colors"
+                    >
+                      <ExternalLink size={10} />
+                      設定方法の解説記事（Qiita）
+                    </a>
+                  </div>
+                </div>
+              </div>
 
               {/* ステップ1: キーを取得 */}
               <div className="bg-slate-800/50 rounded-2xl p-4 border border-slate-700">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- CSP: P1 (#179) で CDN スクリプトを撤去後、script-src から jsdelivr/cdnjs を削除すること -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; connect-src 'self' https://generativelanguage.googleapis.com; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; worker-src 'self' blob:;">
     <title>工事写真帳メーカー - Construction Album Maker</title>
     <!-- Tailwind CSS is bundled via PostCSS -->
     <script src="https://cdn.jsdelivr.net/npm/exceljs@4.4.0/dist/exceljs.min.js"></script>


### PR DESCRIPTION
refs #179

Implements P2, P3, P4, P5 of the security hardening issue. P1 (CDN bundling) is handled in a separate branch.

## Changes

### P2: API key restriction guidance UI
- `components/ApiKeySetup.tsx`: prominent red warning block before step 1 asking users to set HTTP referrer restriction (`https://yuujikamura.github.io/GASPhotoAIManager/*`), API restriction (Generative Language API only), and a $5/month budget alert.
- Links to Google Cloud Console credentials page and the Qiita walk-through (`https://qiita.com/pythonista0328/items/f9eb8b7fb6a14087df35`).
- Uses existing Tailwind palette and `lucide-react` `Shield` / `AlertTriangle` icons.

### P3: Real SECURITY.md
- Replace GitHub default template (which listed fake versions like `5.1.x`) with real content: private reporting via GitHub Security Advisories, `main`-only support, and BYOK threat model scoped to XSS / supply chain and build-time key injection.

### P4: Secret scanning automation
- New `.github/workflows/secret-scan.yml`: gitleaks on every push / PR.
- `deploy.yml`: after `npm run build`, fail if dist contains `AIza[A-Za-z0-9_-]{35}` or any `*.map` file.

### P5: CSP meta tag
- `index.html`: add a CSP allowing `'self'` + inline, with `connect-src` locked to `https://generativelanguage.googleapis.com` and `script-src` still permitting `cdn.jsdelivr.net` / `cdnjs.cloudflare.com` until P1 removes the CDN `<script>` tags. Inline comment flags the follow-up tightening.

## Issue checklist (#179)

- [x] P2: ApiKeySetup に HTTP リファラー制限案内
- [x] P3: SECURITY.md を実体のある内容に
- [x] P4: Secret scanning 自動化 (gitleaks + deploy guard)
- [x] P5: CSP meta タグ

## Verification

- `npm run build` passes (8.5s, 0 errors).
- No `AIza...` strings in build output.
- Pre-existing TS errors in `tests/**` and `utils/excelGenerator.ts` are unrelated to this PR and also present on `main`.

Note: the `.map` guard in `deploy.yml` assumes sourcemaps are disabled — currently `vite.config.ts` has `sourcemap: true`, which the separate `security/harden-vite-config` branch addresses. Merge ordering: `harden-vite-config` (or P1) before this PR, or flip `sourcemap: false` here if that branch lands later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)