### PR TITLE
security: hardening — guidance + SECURITY + gitleaks + CSP (P2-P5 of #179)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,17 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify no secrets in build artifact
+        run: |
+          if grep -rE 'AIza[A-Za-z0-9_-]{35}' dist/; then
+            echo "::error::API key found in build output"
+            exit 1
+          fi
+          if find dist -name '*.map' | grep -q .; then
+            echo "::error::Sourcemap leaked to dist"
+            exit 1
+          fi
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
         with:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,12 @@
+name: Secret Scan
+on: [push, pull_request]
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,26 @@
 # Security Policy
 
-## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
-
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Please report security vulnerabilities privately via GitHub Security Advisories:
+https://github.com/YuujiKamura/GASPhotoAIManager/security/advisories/new
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Do NOT open a public issue for security problems.
+
+We aim to respond within 7 days.
+
+## Supported Versions
+
+Only the `main` branch is supported. This is a personal project with no versioned releases.
+
+## Threat Model
+
+This app is a browser-only BYOK (Bring Your Own Key) tool. Users provide their own Google AI Studio API key, stored in localStorage. The app has no backend that handles user keys.
+
+Primary risks we care about:
+- XSS / supply chain: any compromise that reads localStorage
+- Build-time key injection: keys embedded into client bundle at build time
+
+Out of scope:
+- DoS of the static site
+- Abuse of the user's own API key by themselves

--- a/components/ApiKeySetup.tsx
+++ b/components/ApiKeySetup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ExternalLink, Key, Camera, ArrowLeft, Shield, Trash2, CheckCircle } from 'lucide-react';
+import { ExternalLink, Key, Camera, ArrowLeft, Shield, Trash2, CheckCircle, AlertTriangle } from 'lucide-react';
 import { useApiKeySetupState } from '../hooks/useApiKeySetupState';
 
 interface ApiKeySetupProps {
@@ -122,6 +122,70 @@ const ApiKeySetup: React.FC<ApiKeySetupProps> = ({ onComplete, onCancel, onImpor
                   <div className="flex-1 h-px bg-slate-700"></div>
                 </div>
               )}
+
+              {/* セキュリティ警告: キー制限のお願い */}
+              <div className="bg-red-500/10 border border-red-500/40 rounded-2xl p-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <AlertTriangle size={18} className="text-red-400 shrink-0" />
+                  <span className="text-sm font-bold text-red-300">
+                    ⚠️ 安全のため、キーには必ず制限をかけてください
+                  </span>
+                </div>
+                <div className="text-xs text-slate-300 space-y-2">
+                  <p>
+                    キーが漏洩しても悪用されないよう、Google Cloud Console で以下の制限を設定してください：
+                  </p>
+                  <div className="bg-slate-900/60 rounded-lg p-3 space-y-2">
+                    <div>
+                      <div className="flex items-center gap-1 mb-1">
+                        <Shield size={12} className="text-amber-400" />
+                        <span className="text-[11px] font-bold text-amber-300">HTTP リファラー制限</span>
+                      </div>
+                      <code className="block text-[10px] text-slate-200 font-mono bg-slate-950/60 px-2 py-1 rounded break-all">
+                        https://yuujikamura.github.io/GASPhotoAIManager/*
+                      </code>
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-1 mb-1">
+                        <Shield size={12} className="text-amber-400" />
+                        <span className="text-[11px] font-bold text-amber-300">API 制限</span>
+                      </div>
+                      <p className="text-[11px] text-slate-300">
+                        「Generative Language API」のみ許可
+                      </p>
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-1 mb-1">
+                        <Shield size={12} className="text-amber-400" />
+                        <span className="text-[11px] font-bold text-amber-300">予算アラート（推奨）</span>
+                      </div>
+                      <p className="text-[11px] text-slate-300">
+                        月 $5 程度でアラートを設定しておくと安心です
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-1.5 pt-1">
+                    <a
+                      href="https://console.cloud.google.com/apis/credentials"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1 text-[11px] text-blue-400 hover:text-blue-300 transition-colors"
+                    >
+                      <ExternalLink size={10} />
+                      Google Cloud Console 認証情報ページを開く
+                    </a>
+                    <a
+                      href="https://qiita.com/pythonista0328/items/f9eb8b7fb6a14087df35"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1 text-[11px] text-blue-400 hover:text-blue-300 transition-colors"
+                    >
+                      <ExternalLink size={10} />
+                      設定方法の解説記事（Qiita）
+                    </a>
+                  </div>
+                </div>
+              </div>
 
               {/* ステップ1: キーを取得 */}
               <div className="bg-slate-800/50 rounded-2xl p-4 border border-slate-700">


### PR DESCRIPTION
## Summary

#181 の rebase 版（旧ブランチは force-push がブランチ保護で拒否されたため新ブランチで再提出）。P2-P5 of #179。

- **P2**: `components/ApiKeySetup.tsx` に HTTP リファラー制限 / API 制限 / 課金アラートを促す警告ブロック追加
- **P3**: `SECURITY.md` を GitHub デフォルトテンプレから実体のある報告窓口 + 脅威モデル記載に置換
- **P4**: `.github/workflows/secret-scan.yml` (gitleaks) 新設 + `deploy.yml` に AIza grep + `.map` guard 追加
- **P5**: `index.html` に CSP meta 追加（script-src は #182 で CDN 撤去済みなので `'self' 'unsafe-inline'` まで絞った状態でコンフリクト解消）

## Verification

- main への rebase 済み、コンフリクトは `index.html` の CSP コメント/値のみ（#182 の clean 版を採用）
- `npm run build` は rebase 前の agent 作業時に確認済

refs #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)