### PR TITLE
test: smoke tests for npm-bundled ExcelJS / JSZip / file-saver

### DIFF
--- a/tests/excelGenerator.smoke.test.ts
+++ b/tests/excelGenerator.smoke.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import ExcelJS from 'exceljs';
+import { saveAs } from 'file-saver';
+
+describe('bundled npm imports (smoke tests for PR #182 migration)', () => {
+  it('ExcelJS default export constructs a Workbook', () => {
+    const workbook = new ExcelJS.Workbook();
+    expect(workbook).toBeDefined();
+    expect(typeof workbook.addWorksheet).toBe('function');
+
+    const sheet = workbook.addWorksheet('Test');
+    sheet.addRow(['a', 'b', 'c']);
+    expect(sheet.rowCount).toBe(1);
+  });
+
+  it('ExcelJS Workbook serializes to a buffer', async () => {
+    const wb = new ExcelJS.Workbook();
+    const sheet = wb.addWorksheet('S');
+    sheet.addRow([1, 2, 3]);
+    const buf = await wb.xlsx.writeBuffer();
+    expect(buf.byteLength).toBeGreaterThan(0);
+  });
+
+  it('file-saver named export saveAs is a function', () => {
+    expect(typeof saveAs).toBe('function');
+  });
+});

--- a/tests/zipGenerator.test.ts
+++ b/tests/zipGenerator.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { generateZip } from '../utils/zipGenerator';
+import { PhotoRecord } from '../types';
+
+const TINY_JPEG_B64 =
+  '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AL+AH//Z';
+
+const makePhoto = (i: number): PhotoRecord => ({
+  fileName: `photo_${i}.jpg`,
+  base64: `data:image/jpeg;base64,${TINY_JPEG_B64}`,
+  mimeType: 'image/jpeg',
+  fileSize: 100,
+  lastModified: Date.now(),
+  status: 'done' as const,
+  analysis: {
+    fileName: `photo_${i}.jpg`,
+    workType: '土工',
+    variety: '掘削',
+    detail: '作業',
+    station: 'No.1',
+    remarks: '',
+    description: '',
+    hasBoard: false,
+    detectedText: '',
+  },
+});
+
+describe('zipGenerator (bundled JSZip smoke test)', () => {
+  it('JSZip default export is callable', () => {
+    const zip = new JSZip();
+    expect(zip).toBeDefined();
+    expect(typeof zip.folder).toBe('function');
+    expect(typeof zip.generateAsync).toBe('function');
+  });
+
+  it('generateZip returns a non-empty Blob from bundled JSZip', async () => {
+    const records = [makePhoto(1), makePhoto(2)];
+    const blob = await generateZip(records);
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(0);
+    expect(blob.type).toMatch(/zip|octet-stream/);
+  });
+
+  it('JSZip can build and parse a zip via nodebuffer (roundtrip without Blob)', async () => {
+    const zip = new JSZip();
+    zip.file('a.txt', 'hello');
+    zip.folder('sub')!.file('b.txt', 'world');
+    const buf = await zip.generateAsync({ type: 'nodebuffer' });
+
+    const parsed = await JSZip.loadAsync(buf);
+    expect(parsed.file('a.txt')).not.toBeNull();
+    expect(parsed.file('sub/b.txt')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

#182 で CDN → npm に切り替えた 3 ライブラリ (ExcelJS / JSZip / file-saver) が ESM/CJS 解決や default/named export の形で壊れていないことを自動検証する smoke test を追加。これまで動作確認が手動頼みだった穴を塞ぐ。

## Added tests

- `tests/zipGenerator.test.ts`
  - JSZip default export の callable 性
  - `generateZip()` が非空 Blob を返すこと
  - zip generate/loadAsync の nodebuffer roundtrip
- `tests/excelGenerator.smoke.test.ts`
  - `new ExcelJS.Workbook()` 構築
  - `workbook.xlsx.writeBuffer()` の書出し
  - `file-saver` の named export `saveAs` が function であること

## 除外理由

- **PDF**: `utils/pdfGenerator.ts` は pdf-lib + 日本語フォント loader + `fontkit` を絡める複雑系で smoke test のコスト/価値バランスが合わないため、今回は対象外
- **EXIF**: 既存 `tests/imageUtils.test.ts` でカバー済
- **Blob.arrayBuffer()**: jsdom の Blob 実装に当該メソッドがないので roundtrip は `generateAsync({ type: 'nodebuffer' })` 経由に切替

## Test run

```
Test Files  2 passed (2)
     Tests  6 passed (6)
```

refs #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)