### PR TITLE
test: smoke test for pdf-lib + fontkit (completes #179 bundled-lib coverage)

### DIFF
--- a/tests/pdfGenerator.smoke.test.ts
+++ b/tests/pdfGenerator.smoke.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+import fontkit from '@pdf-lib/fontkit';
+
+describe('pdf-lib smoke tests (ensures ESM/CJS resolution stays healthy)', () => {
+  it('pdf-lib named exports are available', () => {
+    expect(typeof PDFDocument.create).toBe('function');
+    expect(StandardFonts.Helvetica).toBeTruthy();
+    expect(typeof rgb).toBe('function');
+  });
+
+  it('fontkit default export is registrable on a PDFDocument', async () => {
+    const doc = await PDFDocument.create();
+    expect(() => doc.registerFontkit(fontkit)).not.toThrow();
+  });
+
+  it('PDFDocument builds a minimal PDF and roundtrips via load()', async () => {
+    const doc = await PDFDocument.create();
+    const font = await doc.embedFont(StandardFonts.Helvetica);
+    const page = doc.addPage([200, 100]);
+    page.drawText('Smoke OK', { x: 20, y: 40, size: 18, font, color: rgb(0, 0, 0) });
+
+    const bytes = await doc.save();
+    expect(bytes.byteLength).toBeGreaterThan(100);
+
+    // PDF magic header "%PDF-"
+    expect(bytes[0]).toBe(0x25);
+    expect(bytes[1]).toBe(0x50);
+    expect(bytes[2]).toBe(0x44);
+    expect(bytes[3]).toBe(0x46);
+
+    const reloaded = await PDFDocument.load(bytes);
+    expect(reloaded.getPageCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

#184 の後続。PDF エクスポート (`utils/pdfGenerator.ts`) が依存する pdf-lib / @pdf-lib/fontkit の npm import が壊れていないことを自動検証する smoke test を追加。

## Scope

- `PDFDocument.create / save / load` のラウンドトリップ
- `StandardFonts.Helvetica` での `embedFont`
- `fontkit` default export の `registerFontkit` への受渡し
- 出力バイト列に PDF magic header (`%PDF-`) が入ること

日本語フォント loader (`loadJapaneseFont`) は `fetch('/GASPhotoAIManager/fonts/ipaexg.ttf')` 依存で jsdom では再現不可能なので、Helvetica + StandardFonts で network なしの minimal PDF を組む形にした。

## Coverage 状態

これで #179 で扱った npm bundle migration の 4 大フロー (Excel / PDF / ZIP / EXIF) が全て自動テストでカバーされた:

| flow | lib | test |
|---|---|---|
| Excel | exceljs + file-saver | `tests/excelGenerator.smoke.test.ts` (#184) |
| PDF | pdf-lib + fontkit | `tests/pdfGenerator.smoke.test.ts` (this) |
| ZIP | jszip | `tests/zipGenerator.test.ts` (#184) |
| EXIF | exif-js | `tests/imageUtils.test.ts` (既存) |

## Test run

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

refs #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)